### PR TITLE
Replace Temad PNG assets with SVG equivalents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.gif
 *.svg
 
+# Allow checked-in SVG illustrations for the product page
+!ui/product-page/assets/images/*.svg
+
 # Fonts
 *.woff
 *.woff2

--- a/ui/product-page/assets/app.js
+++ b/ui/product-page/assets/app.js
@@ -43,6 +43,7 @@ const suppliers = [
     subtitle: 'Tehran, Iran · Est. 1977',
     rating: 4.2,
     badge: 'Verified',
+    logo: 'assets/images/temad-logo.svg',
     compliance: ['gmp'],
     forms: ['granules', 'powder'],
     regions: ['asia'],
@@ -53,7 +54,7 @@ const suppliers = [
     certifications: ['ISO 9001'],
     leadTime: '18 days',
     volume: '60T yearly',
-    hero: 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=400&q=80',
+    hero: 'assets/images/temad-facility.svg',
     tags: ['Rapid dispatch', 'Flexible MOQs'],
   },
   {

--- a/ui/product-page/assets/images/temad-facility.svg
+++ b/ui/product-page/assets/images/temad-facility.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" role="img" aria-labelledby="title desc">
+  <title id="title">Temad manufacturing facility</title>
+  <desc id="desc">Stylised illustration of an industrial pharmaceutical plant with silos and office block.</desc>
+  <rect width="160" height="120" fill="#f4f7fb" rx="12"/>
+  <path d="M20 86h120v18H20z" fill="#c5d8e8"/>
+  <rect x="30" y="38" width="44" height="48" rx="6" fill="#e2edf7"/>
+  <rect x="82" y="30" width="32" height="56" rx="6" fill="#d2e4f4"/>
+  <rect x="118" y="46" width="18" height="40" rx="5" fill="#b7d1e5"/>
+  <rect x="38" y="46" width="12" height="12" rx="2" fill="#ffffff"/>
+  <rect x="58" y="46" width="12" height="12" rx="2" fill="#ffffff"/>
+  <rect x="38" y="64" width="12" height="12" rx="2" fill="#ffffff"/>
+  <rect x="58" y="64" width="12" height="12" rx="2" fill="#ffffff"/>
+  <rect x="90" y="38" width="16" height="14" rx="2" fill="#ffffff"/>
+  <rect x="90" y="58" width="16" height="26" rx="2" fill="#ffffff"/>
+  <path d="M24 86V74c0-6 4-10 10-10h28c6 0 10 4 10 10v12" fill="#6da8d6" opacity="0.25"/>
+  <path d="M116 30c0-6 4-10 10-10s10 4 10 10v16h-20V30z" fill="#6da8d6" opacity="0.3"/>
+  <path d="M28 86h44" stroke="#6da8d6" stroke-width="4" stroke-linecap="round"/>
+  <path d="M82 86h34" stroke="#6da8d6" stroke-width="4" stroke-linecap="round"/>
+  <path d="M122 86h12" stroke="#6da8d6" stroke-width="4" stroke-linecap="round"/>
+  <path d="M34 38h36" stroke="#6da8d6" stroke-width="4" stroke-linecap="round"/>
+  <path d="M82 30h32" stroke="#6da8d6" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="126" cy="32" r="4" fill="#ffffff"/>
+</svg>

--- a/ui/product-page/assets/images/temad-logo.svg
+++ b/ui/product-page/assets/images/temad-logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 40" role="img" aria-labelledby="logoTitle logoDesc">
+  <title id="logoTitle">Temad company logo</title>
+  <desc id="logoDesc">Geometric wordmark for Temad with rounded lettering and accent underline.</desc>
+  <rect width="140" height="40" rx="8" fill="#ffffff"/>
+  <g fill="#36677f">
+    <path d="M16 12h8v3.4h-2.2V28h-3.6V15.4H16z"/>
+    <path d="M32.6 11.8c4 0 7 2.8 7 8.1 0 5.3-3 8.3-7 8.3s-7-3-7-8.3c0-5.3 3-8.1 7-8.1zm0 3.5c-1.8 0-3.2 1.5-3.2 4.6 0 3.1 1.4 4.8 3.2 4.8s3.2-1.7 3.2-4.8c0-3.1-1.4-4.6-3.2-4.6z"/>
+    <path d="M48.4 12h5.5l2.8 6.8h.1l2.8-6.8h5.5V28h-3.4l.1-11.5h-.1l-3.2 7.8h-2.5l-3.2-7.8h-.1l.1 11.5h-3.4z"/>
+    <path d="M75.8 12h3.6v6.2h6V12h3.6v16h-3.6v-6.4h-6V28h-3.6z"/>
+    <path d="M100.4 12h4.9l5.8 10.2h.1V12h3.6v16h-4.7l-6-10.5h-.1V28h-3.6z"/>
+  </g>
+  <path d="M18 32h104" stroke="#6da8d6" stroke-width="3" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- allow checking in curated SVG artwork within the product page assets folder
- add Temad facility and logo illustrations as accessible SVGs
- point the Temad supplier data to the new SVG assets instead of the old PNG references

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db9249a110832499b29a821ccc5908