### PR TITLE
Replace header logo and refresh supplier branding

### DIFF
--- a/ui/product-page/assets/app.js
+++ b/ui/product-page/assets/app.js
@@ -1,0 +1,516 @@
+const suppliers = [
+  {
+    id: 'arshine',
+    name: 'Arshine Pharmaceutical Co.',
+    subtitle: 'Shenzhen, China · Est. 2007',
+    rating: 4.6,
+    badge: 'Featured',
+    compliance: ['gmp', 'who'],
+    forms: ['powder'],
+    regions: ['asia'],
+    response: 24,
+    moq: 200,
+    price: 455,
+    responseScore: 90,
+    certifications: ['WHO', 'ISO 14001'],
+    leadTime: '16 days',
+    volume: '95T yearly',
+    logo: 'https://pharmaoffer.com/media/cache/rmcl/upload/logo/logo-Arshine.webp?version=20252209',
+    facility:
+      'https://pharmaoffer.com/media/cache/rmci/upload/picture/656749f005ad5315033402.webp',
+    tags: ['WHO prequalified', 'Sustainability'],
+  },
+  {
+    id: 'sinoway',
+    name: 'Sinoway Industrial Co. Ltd',
+    subtitle: 'Hangzhou, China · Est. 1993',
+    rating: 4.8,
+    badge: 'Verified',
+    compliance: ['gmp'],
+    forms: ['powder'],
+    regions: ['asia'],
+    response: 18,
+    moq: 250,
+    price: 462,
+    responseScore: 93,
+    certifications: ['CEP', 'EDMF'],
+    leadTime: '19 days',
+    volume: '120T yearly',
+    logo: 'https://pharmaoffer.com/media/cache/rmcl/upload/logo/sinoway-industrial-co-ltd.webp?version=20252509',
+    facility:
+      'https://pharmaoffer.com/media/cache/rmci/upload/picture/67fcdcab3b980775300906.webp',
+    tags: ['GMP', 'In stock', 'Audit ready'],
+  },
+  {
+    id: 'temad',
+    name: 'Temad Co.',
+    subtitle: 'Tehran, Iran · Est. 1977',
+    rating: 4.2,
+    badge: 'Verified',
+    compliance: ['gmp'],
+    forms: ['granules', 'powder'],
+    regions: ['asia'],
+    response: 40,
+    moq: 150,
+    price: 440,
+    responseScore: 81,
+    certifications: ['ISO 9001'],
+    leadTime: '18 days',
+    volume: '60T yearly',
+    logo: 'https://pharmaoffer.com/media/cache/rmcl/upload/logo/temad-co.webp?version=20252309',
+    facility:
+      'https://pharmaoffer.com/media/cache/rmci/upload/picture/6540ceb79c522044017715.webp',
+    tags: ['Rapid dispatch', 'Flexible MOQs'],
+  },
+  {
+    id: 'senova',
+    name: 'Senova Technology Co. Ltd',
+    subtitle: 'Shandong, China · Est. 2011',
+    rating: 4.4,
+    badge: 'Verified',
+    compliance: ['gmp'],
+    forms: ['powder', 'granules'],
+    regions: ['asia'],
+    response: 28,
+    moq: 180,
+    price: 470,
+    responseScore: 87,
+    certifications: ['GMP', 'ISO 9001'],
+    leadTime: '20 days',
+    volume: '80T yearly',
+    logo: 'https://pharmaoffer.com/media/cache/rmcl/upload/logo/senova-technology-co-ltd.webp?version=20252209',
+    facility:
+      'https://pharmaoffer.com/media/cache/rmci/upload/picture/63f8a9d778c63910140304.webp',
+    tags: ['Ready stock', 'Regulatory support'],
+  },
+  {
+    id: 'lgm-pharma',
+    name: 'LGM Pharma',
+    subtitle: 'Boca Raton, USA · Est. 2006',
+    rating: 4.7,
+    badge: 'Premium',
+    compliance: ['gmp', 'fda'],
+    forms: ['powder'],
+    regions: ['americas'],
+    response: 22,
+    moq: 320,
+    price: 515,
+    responseScore: 94,
+    certifications: ['US FDA', 'cGMP'],
+    leadTime: '22 days',
+    volume: '110T yearly',
+    logo: 'https://pharmaoffer.com/media/cache/rmcl/upload/logo/x.webp?version=20252209',
+    facility:
+      'https://pharmaoffer.com/media/cache/rmci/upload/picture/64c10bb925a82131199569.webp',
+    tags: ['Regulatory support', 'North America hub'],
+  },
+  {
+    id: 'duchefa',
+    name: 'Duchefa Farma B.V.',
+    subtitle: 'Haarlem, Netherlands · Est. 1986',
+    rating: 4.5,
+    badge: 'Featured',
+    compliance: ['gmp', 'fda'],
+    forms: ['powder'],
+    regions: ['europe'],
+    response: 32,
+    moq: 210,
+    price: 488,
+    responseScore: 89,
+    certifications: ['EU GMP', 'FDA'],
+    leadTime: '24 days',
+    volume: '90T yearly',
+    logo: 'https://pharmaoffer.com/media/cache/rmcl/upload/logo/duchefa-farma-b-v.webp?version=20252209',
+    facility:
+      'https://pharmaoffer.com/media/cache/rmci/upload/picture/639ade03a2fae504874189.webp',
+    tags: ['EU release', 'Audit ready'],
+  },
+];
+
+const template = document.getElementById('supplier-card-template');
+const listEl = document.getElementById('supplier-list');
+const resultsCountEl = document.getElementById('results-count');
+const selectionBar = document.getElementById('selection-bar');
+const selectedCountEl = document.getElementById('selected-count');
+const clearSelectionBtn = document.getElementById('clear-selection');
+const compareBtn = document.getElementById('compare-btn');
+const compareModal = document.getElementById('compare-modal');
+const compareContent = document.getElementById('compare-content');
+const modalClose = compareModal.querySelector('.modal__close');
+const filtersForm = document.getElementById('filters-form');
+const moqRange = document.getElementById('moq');
+const moqValue = document.getElementById('moq-value');
+const resetFiltersBtn = document.getElementById('reset-filters');
+const sortOrderSelect = document.getElementById('sort-order');
+const bulkCta = document.getElementById('bulk-cta');
+const inquiryAction = document.getElementById('inquiry-action');
+const selectionCompare = document.getElementById('selection-compare');
+const transactionalDial = document.querySelector('[data-role="transactional-dial"]');
+const siteSearchForm = document.querySelector('.site-header__search');
+
+const state = {
+  selected: new Set(),
+  filters: {
+    compliance: new Set(),
+    region: new Set(),
+    form: new Set(),
+    response: null,
+    moq: Number(moqRange?.value || 0),
+  },
+  sort: 'relevance',
+};
+
+const initTransactionalDial = () => {
+  if (!transactionalDial) return;
+
+  const rawValue = Number(transactionalDial.dataset.value);
+  const value = Number.isFinite(rawValue)
+    ? Math.max(0, Math.min(100, Math.round(rawValue)))
+    : 0;
+
+  const sweep = (value / 100) * 270;
+  const fillDegrees = `${sweep}deg`;
+  const rotation = `${-135 + sweep}deg`;
+
+  let activeColor = 'var(--brand-secondary)';
+  let trackColor = 'rgba(60, 177, 195, 0.18)';
+
+  if (value >= 80) {
+    activeColor = 'var(--brand-secondary)';
+    trackColor = 'rgba(60, 177, 195, 0.16)';
+  } else if (value >= 55) {
+    activeColor = 'var(--brand-primary)';
+    trackColor = 'rgba(54, 103, 127, 0.16)';
+  } else {
+    activeColor = 'var(--brand-accent)';
+    trackColor = 'rgba(239, 81, 125, 0.18)';
+  }
+
+  transactionalDial.style.setProperty('--dial-fill', fillDegrees);
+  transactionalDial.style.setProperty('--dial-rotation', rotation);
+  transactionalDial.style.setProperty('--dial-active', activeColor);
+  transactionalDial.style.setProperty('--dial-track', trackColor);
+  transactionalDial.dataset.value = String(value);
+  transactionalDial.setAttribute(
+    'aria-label',
+    `Transactional health score ${value} out of 100`,
+  );
+
+  const valueLabel = transactionalDial.querySelector('.dial__value');
+  if (valueLabel) {
+    valueLabel.textContent = String(value);
+  }
+
+  const statusChip = transactionalDial.closest('.insight-card')?.querySelector('.chip');
+  if (statusChip) {
+    statusChip.classList.remove('chip--positive', 'chip--neutral', 'chip--warning');
+
+    let nextClass = 'chip--neutral';
+    let nextLabel = 'Stable';
+
+    if (value >= 80) {
+      nextClass = 'chip--positive';
+      nextLabel = 'Improving';
+    } else if (value < 55) {
+      nextClass = 'chip--warning';
+      nextLabel = 'Needs attention';
+    }
+
+    statusChip.classList.add(nextClass);
+    statusChip.textContent = nextLabel;
+  }
+};
+
+const formatCurrency = (value) => `$${value.toLocaleString()} / kg`;
+
+const renderSupplierCard = (supplier) => {
+  const card = template.content.firstElementChild.cloneNode(true);
+  const checkbox = card.querySelector('.supplier-checkbox');
+  const logoImage = card.querySelector('.supplier-card__logo');
+  const facilityImage = card.querySelector('.supplier-card__facility');
+  const badge = card.querySelector('.supplier-badge');
+  const title = card.querySelector('h3');
+  const subtitle = card.querySelector('.supplier-card__subtitle');
+  const ratingEl = card.querySelector('.supplier-card__rating');
+  const responseScoreEl = card.querySelector('.supplier-card__response-score');
+  const responseTimeEl = card.querySelector('.supplier-card__response-time');
+  const metaList = card.querySelector('.supplier-card__meta');
+  const tagsContainer = card.querySelector('.supplier-card__tags');
+
+  checkbox.dataset.id = supplier.id;
+  checkbox.checked = state.selected.has(supplier.id);
+
+  logoImage.src = supplier.logo;
+  logoImage.alt = `${supplier.name} logo`;
+
+  if (facilityImage) {
+    facilityImage.src = supplier.facility;
+    facilityImage.alt = `${supplier.name} manufacturing facility`;
+  }
+
+  if (supplier.badge) {
+    badge.textContent = supplier.badge;
+    badge.className = 'supplier-badge';
+    const modifier = supplier.badge.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    badge.classList.add(`supplier-badge--${modifier}`);
+    badge.removeAttribute('hidden');
+  } else {
+    badge.setAttribute('hidden', '');
+  }
+  title.textContent = supplier.name;
+  subtitle.textContent = supplier.subtitle;
+  if (ratingEl) {
+    ratingEl.innerHTML = `
+      <span class="supplier-card__rating-star" aria-hidden="true">★</span>
+      ${supplier.rating.toFixed(1)}
+    `;
+    ratingEl.setAttribute('aria-label', `${supplier.rating.toFixed(1)} out of 5`);
+  }
+  responseScoreEl.textContent = `${supplier.responseScore}%`;
+  const responseUnit = supplier.response === 1 ? 'hour' : 'hours';
+  responseTimeEl.textContent = `Avg. reply in ${supplier.response} ${responseUnit}`;
+
+  const metaItems = [
+    { label: 'MOQ', value: `${supplier.moq} kg` },
+    { label: 'Lead time', value: supplier.leadTime },
+    { label: 'Certifications', value: supplier.certifications.join(', ') },
+    { label: 'Avg. price', value: formatCurrency(supplier.price) },
+  ];
+
+  metaList.innerHTML = metaItems
+    .map(
+      (item) => `
+        <li>
+          <span>${item.label}</span>
+          ${item.value}
+        </li>
+      `
+    )
+    .join('');
+
+  tagsContainer.innerHTML = supplier.tags
+    .map((tag) => `<span>${tag}</span>`)
+    .join('');
+
+  checkbox.addEventListener('change', (event) => {
+    const { checked, dataset } = event.target;
+    if (checked) {
+      state.selected.add(dataset.id);
+    } else {
+      state.selected.delete(dataset.id);
+    }
+    updateSelectionBar();
+  });
+
+  return card;
+};
+
+const applyFilters = () => {
+  const filtered = suppliers.filter((supplier) => {
+    const meetsCompliance =
+      !state.filters.compliance.size ||
+      supplier.compliance.some((item) => state.filters.compliance.has(item));
+
+    const meetsRegion =
+      !state.filters.region.size ||
+      supplier.regions.some((item) => state.filters.region.has(item));
+
+    const meetsForm =
+      !state.filters.form.size ||
+      supplier.forms.some((item) => state.filters.form.has(item));
+
+    const meetsResponse =
+      !state.filters.response || supplier.response <= Number(state.filters.response);
+
+    const meetsMoq = supplier.moq <= state.filters.moq;
+
+    return meetsCompliance && meetsRegion && meetsForm && meetsResponse && meetsMoq;
+  });
+
+  return sortSuppliers(filtered);
+};
+
+const sortSuppliers = (list) => {
+  const sorted = [...list];
+  switch (state.sort) {
+    case 'rating':
+      sorted.sort((a, b) => b.rating - a.rating);
+      break;
+    case 'price':
+      sorted.sort((a, b) => a.price - b.price);
+      break;
+    case 'response':
+      sorted.sort((a, b) => a.response - b.response);
+      break;
+    default:
+      sorted.sort((a, b) => b.responseScore - a.responseScore);
+  }
+  return sorted;
+};
+
+const renderSuppliers = () => {
+  const filteredSuppliers = applyFilters();
+  listEl.innerHTML = '';
+  filteredSuppliers.forEach((supplier) => {
+    listEl.appendChild(renderSupplierCard(supplier));
+  });
+  resultsCountEl.textContent = `Showing ${filteredSuppliers.length} supplier${
+    filteredSuppliers.length === 1 ? '' : 's'
+  }`;
+};
+
+const updateSelectionBar = () => {
+  const count = state.selected.size;
+  selectedCountEl.textContent = `${count} supplier${count === 1 ? '' : 's'} selected`;
+  if (count > 0) {
+    selectionBar.classList.add('is-active');
+  } else {
+    selectionBar.classList.remove('is-active');
+  }
+
+  if (clearSelectionBtn) {
+    clearSelectionBtn.disabled = count === 0;
+  }
+  if (inquiryAction) {
+    inquiryAction.disabled = count === 0;
+  }
+  if (selectionCompare) {
+    selectionCompare.disabled = count === 0;
+  }
+};
+
+const clearSelection = () => {
+  state.selected.clear();
+  document
+    .querySelectorAll('.supplier-checkbox')
+    .forEach((checkbox) => (checkbox.checked = false));
+  updateSelectionBar();
+};
+
+const openCompareModal = () => {
+  const selectedSuppliers = suppliers.filter((supplier) =>
+    state.selected.has(supplier.id)
+  );
+
+  if (!selectedSuppliers.length) {
+    compareModal.setAttribute('hidden', '');
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'compare-table';
+  table.innerHTML = `
+    <thead>
+      <tr>
+        <th>Supplier</th>
+        <th>MOQ</th>
+        <th>Lead time</th>
+        <th>Certifications</th>
+        <th>Avg. price</th>
+        <th>Response</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${selectedSuppliers
+        .map(
+          (supplier) => `
+            <tr>
+              <td>
+                <div class="compare-supplier">
+                  <img src="${supplier.logo}" alt="${supplier.name} logo" />
+                  <span>${supplier.name}</span>
+                </div>
+              </td>
+              <td>${supplier.moq} kg</td>
+              <td>${supplier.leadTime}</td>
+              <td>${supplier.certifications.join(', ')}</td>
+              <td>${formatCurrency(supplier.price)}</td>
+              <td>${supplier.response} h</td>
+            </tr>
+          `
+        )
+        .join('')}
+    </tbody>
+  `;
+
+  compareContent.innerHTML = '';
+  compareContent.appendChild(table);
+  compareModal.removeAttribute('hidden');
+};
+
+const initRange = () => {
+  if (!moqRange) return;
+  const update = () => {
+    state.filters.moq = Number(moqRange.value);
+    moqValue.textContent = `Up to ${moqRange.value} kg`;
+    renderSuppliers();
+  };
+  moqRange.addEventListener('input', update);
+  update();
+};
+
+const updateFiltersFromForm = () => {
+  const formData = new FormData(filtersForm);
+  ['compliance', 'region', 'form'].forEach((key) => {
+    state.filters[key] = new Set(formData.getAll(key));
+  });
+  state.filters.response = formData.get('response');
+  renderSuppliers();
+};
+
+filtersForm?.addEventListener('change', updateFiltersFromForm);
+resetFiltersBtn?.addEventListener('click', () => {
+  filtersForm.reset();
+  state.filters.compliance.clear();
+  state.filters.region.clear();
+  state.filters.form.clear();
+  state.filters.response = null;
+  moqRange.value = 500;
+  state.filters.moq = Number(moqRange.value);
+  moqValue.textContent = `Up to ${moqRange.value} kg`;
+  renderSuppliers();
+});
+
+clearSelectionBtn?.addEventListener('click', clearSelection);
+compareBtn?.addEventListener('click', () => {
+  if (!state.selected.size) return;
+  openCompareModal();
+});
+
+selectionCompare?.addEventListener('click', () => {
+  if (!state.selected.size) return;
+  openCompareModal();
+});
+
+siteSearchForm?.addEventListener('submit', (event) => {
+  event.preventDefault();
+});
+
+modalClose?.addEventListener('click', () => {
+  compareModal.setAttribute('hidden', '');
+});
+
+compareModal?.addEventListener('click', (event) => {
+  if (event.target === compareModal) {
+    compareModal.setAttribute('hidden', '');
+  }
+});
+
+bulkCta?.addEventListener('click', () => {
+  selectionBar.classList.add('is-active');
+});
+
+inquiryAction?.addEventListener('click', () => {
+  alert(`Inquiry submitted to ${state.selected.size} suppliers`);
+  clearSelection();
+});
+
+sortOrderSelect?.addEventListener('change', (event) => {
+  state.sort = event.target.value;
+  renderSuppliers();
+});
+
+initTransactionalDial();
+initRange();
+renderSuppliers();
+updateSelectionBar();

--- a/ui/product-page/assets/images/amoli-logo.svg
+++ b/ui/product-page/assets/images/amoli-logo.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="64" viewBox="0 0 180 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="64" rx="14" fill="#383838"/>
+  <path d="M30 43L44 20L58 43H30Z" fill="#3CB1C3"/>
+  <path d="M44 26L52 43H36L44 26Z" fill="#8DCFDB"/>
+  <text x="70" y="38" fill="#F3F9FB" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="700">AMOLI</text>
+</svg>

--- a/ui/product-page/assets/images/arshine-logo.svg
+++ b/ui/product-page/assets/images/arshine-logo.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="64" viewBox="0 0 180 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="64" rx="14" fill="#8DCFDB"/>
+  <path d="M32 44L44 20L56 44H32Z" fill="#36677F"/>
+  <circle cx="44" cy="30" r="6" fill="#EF517D"/>
+  <text x="70" y="38" fill="#1F4B5C" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="700">ARSHINE</text>
+</svg>

--- a/ui/product-page/assets/images/grindeks-logo.svg
+++ b/ui/product-page/assets/images/grindeks-logo.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="64" viewBox="0 0 180 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="64" rx="14" fill="#2F5A70"/>
+  <circle cx="44" cy="32" r="16" fill="#3CB1C3"/>
+  <rect x="38" y="24" width="12" height="16" rx="3" fill="#ffffff"/>
+  <text x="70" y="38" fill="#E4F6F9" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="700">GRINDEKS</text>
+</svg>

--- a/ui/product-page/assets/images/polpharma-logo.svg
+++ b/ui/product-page/assets/images/polpharma-logo.svg
@@ -1,0 +1,6 @@
+<svg width="180" height="64" viewBox="0 0 180 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="64" rx="14" fill="#3CB1C3"/>
+  <circle cx="44" cy="32" r="18" fill="#36677F"/>
+  <path d="M44 22L50.196 36H37.804L44 22Z" fill="#8DCFDB"/>
+  <text x="70" y="38" fill="#083544" font-family="'Inter', 'Segoe UI', sans-serif" font-size="20" font-weight="700">POLPHARMA</text>
+</svg>

--- a/ui/product-page/assets/images/sinoway-logo.svg
+++ b/ui/product-page/assets/images/sinoway-logo.svg
@@ -1,0 +1,5 @@
+<svg width="180" height="64" viewBox="0 0 180 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="64" rx="14" fill="#36677F"/>
+  <path d="M38 21C32.4772 21 28 25.4772 28 31C28 36.5228 32.4772 41 38 41H52L48.5 35.5C50.433 34.3261 51.7 32.0719 51.7 29.5C51.7 24.8056 47.6944 21 43 21H38Z" fill="#8DCFDB"/>
+  <text x="70" y="38" fill="white" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="700">SINOWAY</text>
+</svg>

--- a/ui/product-page/assets/images/temad-logo.svg
+++ b/ui/product-page/assets/images/temad-logo.svg
@@ -1,0 +1,7 @@
+<svg width="160" height="80" viewBox="0 0 160 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="160" height="80" rx="16" fill="#36677F"/>
+  <path d="M40 54L54 26H66L80 54H69.6L66.8 48H53.2L50.4 54H40ZM56.4 41.6H63.6L60 33.6L56.4 41.6Z" fill="#ffffff" opacity="0.94"/>
+  <path d="M86 54V26H100.8C108 26 112.8 30.6 112.8 39.8C112.8 49 108 54 100.8 54H86ZM95.6 46.6H101C103.8 46.6 105.6 44.2 105.6 39.8C105.6 35.4 103.8 33.2 101 33.2H95.6V46.6Z" fill="#8DCFDB"/>
+  <circle cx="126" cy="40" r="14" stroke="#3CB1C3" stroke-width="4" fill="none"/>
+  <path d="M120 40H132" stroke="#EF517D" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/ui/product-page/assets/images/teva-logo.svg
+++ b/ui/product-page/assets/images/teva-logo.svg
@@ -1,0 +1,5 @@
+<svg width="180" height="64" viewBox="0 0 180 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="180" height="64" rx="14" fill="#1F8A9D"/>
+  <path d="M34 40H54C58.4183 40 62 36.4183 62 32C62 27.5817 58.4183 24 54 24H46L42 18H34V40Z" fill="#8DCFDB"/>
+  <text x="70" y="38" fill="#F4FEFF" font-family="'Inter', 'Segoe UI', sans-serif" font-size="22" font-weight="700">TEVA</text>
+</svg>

--- a/ui/product-page/assets/styles.css
+++ b/ui/product-page/assets/styles.css
@@ -1,0 +1,1248 @@
+:root {
+  --brand-primary: #36677f;
+  --brand-secondary: #3cb1c3;
+  --brand-accent: #ef517d;
+  --brand-light: #8dcfdb;
+  --brand-dark: #383838;
+  --surface: #ffffff;
+  --surface-alt: #f2f6f7;
+  --border: #d5e2e8;
+  --shadow-sm: 0 8px 24px rgba(20, 53, 76, 0.08);
+  --shadow-md: 0 20px 40px rgba(20, 53, 76, 0.12);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  color: var(--brand-dark);
+  background-color: #f7fbfc;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.page-shell {
+  max-width: 1920px;
+  margin: 0 auto;
+  padding: 48px clamp(32px, 6vw, 96px) 140px;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: var(--surface);
+  box-shadow: 0 10px 30px rgba(20, 53, 76, 0.12);
+}
+
+.site-header__bar {
+  border-bottom: 1px solid rgba(54, 103, 127, 0.1);
+}
+
+.site-header__inner {
+  max-width: 1920px;
+  margin: 0 auto;
+  padding: 14px clamp(28px, 6vw, 96px);
+  display: flex;
+  align-items: center;
+  gap: clamp(16px, 3vw, 32px);
+}
+
+.site-header__brand {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.site-header__brand img {
+  display: block;
+  height: auto;
+  max-width: 184px;
+}
+
+.site-header__search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(141, 207, 219, 0.16);
+  border-radius: 16px;
+  padding: 6px 8px 6px 16px;
+}
+
+.site-header__search input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 15px;
+  font-family: inherit;
+  color: var(--brand-dark);
+}
+
+.site-header__search input:focus {
+  outline: none;
+}
+
+.site-header__actions {
+  display: flex;
+  align-items: center;
+  gap: clamp(12px, 3vw, 24px);
+}
+
+.site-header__actions .btn {
+  white-space: nowrap;
+}
+
+.site-header__link {
+  font-weight: 500;
+  color: var(--brand-dark);
+  text-decoration: none;
+  transition: color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.site-header__link:hover,
+.site-header__link:focus {
+  color: var(--brand-primary);
+}
+
+.site-header__language {
+  border: 1px solid rgba(54, 103, 127, 0.18);
+  background: rgba(141, 207, 219, 0.18);
+  color: var(--brand-primary);
+  border-radius: 14px;
+  padding: 10px 16px;
+  font-weight: 600;
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.site-header__language:hover,
+.site-header__language:focus-visible {
+  box-shadow: 0 10px 20px rgba(60, 177, 195, 0.25);
+  transform: translateY(-1px);
+}
+
+.site-header__nav {
+  display: flex;
+  justify-content: center;
+  background: rgba(141, 207, 219, 0.12);
+}
+
+.site-header__nav ul {
+  width: 100%;
+  max-width: 1920px;
+  margin: 0;
+  padding: 10px clamp(28px, 6vw, 96px);
+  display: flex;
+  align-items: center;
+  gap: clamp(18px, 4vw, 64px);
+  list-style: none;
+}
+
+.site-header__nav a {
+  font-weight: 500;
+  color: rgba(56, 56, 56, 0.8);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.site-header__nav a:hover,
+.site-header__nav a:focus {
+  color: var(--brand-primary);
+}
+
+.masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  margin-bottom: 48px;
+}
+
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: rgba(56, 56, 56, 0.72);
+}
+
+.masthead__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.masthead__title-group h1 {
+  font-size: clamp(32px, 3vw, 44px);
+  margin: 0 0 12px;
+  letter-spacing: -0.5px;
+}
+
+.masthead__title-group p {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.6;
+  color: rgba(56, 56, 56, 0.8);
+}
+
+.masthead__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.meta-card {
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: var(--shadow-sm);
+}
+
+.meta-card strong {
+  font-size: 24px;
+  color: var(--brand-primary);
+}
+
+.meta-card__label {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(56, 56, 56, 0.64);
+}
+
+.meta-card small {
+  color: rgba(56, 56, 56, 0.64);
+}
+
+.insights {
+  background: linear-gradient(135deg, rgba(60, 177, 195, 0.12), rgba(54, 103, 127, 0.18));
+  border-radius: var(--radius-lg);
+  padding: 28px clamp(16px, 3vw, 40px);
+  box-shadow: var(--shadow-sm);
+}
+
+.insights__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.insights__header h2 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.insights__content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.insight-card {
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: inset 0 0 0 1px rgba(54, 103, 127, 0.08);
+  min-height: 0;
+}
+
+.insight-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.insight-card h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.insight-card p {
+  margin: 0;
+  color: rgba(56, 56, 56, 0.72);
+  line-height: 1.5;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: rgba(56, 103, 127, 0.08);
+  color: var(--brand-primary);
+}
+
+.chip--positive {
+  background: rgba(60, 177, 195, 0.14);
+  color: var(--brand-secondary);
+}
+
+.chip--neutral {
+  background: rgba(56, 56, 56, 0.08);
+}
+
+.chip--warning {
+  background: rgba(239, 81, 125, 0.12);
+  color: var(--brand-accent);
+}
+
+.progress-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.progress {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.progress__bar {
+  height: 8px;
+  background: linear-gradient(90deg, var(--brand-secondary), var(--brand-accent));
+  border-radius: 999px;
+}
+
+.progress__value {
+  font-weight: 600;
+  color: var(--brand-primary);
+}
+
+.insight-card__body {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: center;
+}
+
+.insight-card svg {
+  max-height: 120px;
+}
+
+.dial {
+  --dial-fill: 0deg;
+  --dial-rotation: -135deg;
+  --dial-track: rgba(60, 177, 195, 0.16);
+  --dial-active: var(--brand-secondary);
+  --dial-indicator-offset: 74px;
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 168px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: conic-gradient(
+    from -135deg,
+    var(--dial-active) var(--dial-fill),
+    var(--dial-track) var(--dial-fill)
+  );
+  box-shadow: var(--shadow-sm);
+}
+
+.dial::before {
+  content: '';
+  position: absolute;
+  inset: 14px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(54, 103, 127, 0.08);
+  z-index: 1;
+}
+
+.dial__indicator {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 2;
+  transform: rotate(var(--dial-rotation));
+}
+
+.dial__indicator::after {
+  content: '';
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--brand-accent);
+  box-shadow: 0 6px 14px rgba(239, 81, 125, 0.28);
+  transform: translateY(calc(var(--dial-indicator-offset) * -1));
+}
+
+.dial__center {
+  position: relative;
+  display: grid;
+  place-items: center;
+  gap: 4px;
+  z-index: 3;
+  text-align: center;
+}
+
+.dial__value {
+  font-size: 36px;
+  font-weight: 700;
+  color: var(--brand-primary);
+}
+
+.dial small {
+  color: rgba(56, 56, 56, 0.64);
+  font-size: 14px;
+}
+
+.dial__legend {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 14px;
+  color: rgba(56, 56, 56, 0.72);
+}
+
+.btn {
+  border: none;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  font-size: 15px;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn:disabled:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(54, 103, 127, 0.45);
+  outline-offset: 2px;
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--brand-primary), var(--brand-secondary));
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(54, 103, 127, 0.35);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--brand-primary);
+  border: 1px solid rgba(54, 103, 127, 0.24);
+}
+
+.btn--small {
+  padding: 8px 16px;
+  font-size: 14px;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(54, 103, 127, 0.2);
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: 340px minmax(0, 1fr) 400px;
+  gap: 36px;
+  align-items: start;
+}
+
+.filters {
+  position: sticky;
+  top: 32px;
+  align-self: start;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.filters header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.filters h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.filters fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.filters legend {
+  font-weight: 600;
+  margin-bottom: 4px;
+  font-size: 14px;
+  color: rgba(56, 56, 56, 0.72);
+}
+
+.filters__reset {
+  border: none;
+  background: none;
+  color: var(--brand-secondary);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.control {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: rgba(56, 56, 56, 0.84);
+}
+
+.control input {
+  accent-color: var(--brand-primary);
+}
+
+.control--radio input {
+  width: 18px;
+  height: 18px;
+}
+
+.control--checkbox input {
+  width: 18px;
+  height: 18px;
+}
+
+.control--select {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: rgba(56, 56, 56, 0.72);
+}
+
+.control--select select {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(54, 103, 127, 0.24);
+  font-size: 14px;
+}
+
+.range-value {
+  font-size: 13px;
+  color: rgba(56, 56, 56, 0.68);
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.results__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surface);
+  padding: 20px 24px;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.supplier-list {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.supplier-card {
+  display: grid;
+  grid-template-columns: auto minmax(180px, 220px) minmax(0, 2fr) minmax(190px, 220px);
+  grid-template-areas: 'selector branding body aside';
+  gap: 24px;
+  padding: 24px;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  align-items: start;
+  position: relative;
+  transition: transform 0.2s ease;
+}
+
+.supplier-card:hover {
+  transform: translateY(-4px);
+}
+
+.supplier-card__selector {
+  position: relative;
+  display: grid;
+  place-items: center;
+  grid-area: selector;
+}
+
+.supplier-card__selector input {
+  position: absolute;
+  opacity: 0;
+}
+
+.supplier-card__branding {
+  grid-area: branding;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  padding: 4px 0;
+  text-align: center;
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.checkbox-custom {
+  width: 24px;
+  height: 24px;
+  border-radius: 8px;
+  border: 2px solid rgba(54, 103, 127, 0.32);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  transition: all 0.2s ease;
+}
+
+.supplier-card__selector input:checked + .checkbox-custom {
+  background: var(--brand-primary);
+  border-color: var(--brand-primary);
+  box-shadow: 0 10px 20px rgba(54, 103, 127, 0.35);
+}
+
+.supplier-card__selector input:checked + .checkbox-custom::after {
+  content: '\2713';
+  color: #fff;
+  font-size: 16px;
+}
+
+.supplier-card__body {
+  grid-area: body;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.supplier-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+}
+
+.supplier-card__rating {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 14px;
+  background: rgba(141, 207, 219, 0.18);
+  color: var(--brand-primary);
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.supplier-card__rating-star {
+  color: var(--brand-accent);
+  font-size: 16px;
+  line-height: 1;
+}
+
+.supplier-card__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.supplier-card__header h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.supplier-card__subtitle {
+  margin: 4px 0 0;
+  color: rgba(56, 56, 56, 0.64);
+  font-size: 14px;
+}
+
+.supplier-card__meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(180px, 1fr));
+  gap: 14px 32px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 13px;
+  color: rgba(56, 56, 56, 0.68);
+}
+
+.supplier-card__meta li span {
+  display: block;
+  font-weight: 600;
+  color: var(--brand-dark);
+}
+
+.supplier-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.supplier-card__tags span {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(60, 177, 195, 0.16);
+  color: var(--brand-primary);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.supplier-card__aside {
+  grid-area: aside;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-self: stretch;
+}
+
+.supplier-card__response {
+  padding: 16px;
+  border-radius: var(--radius-md);
+  background: rgba(54, 103, 127, 0.08);
+  display: grid;
+  gap: 6px;
+}
+
+.supplier-card__response-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(56, 56, 56, 0.6);
+}
+
+.supplier-card__response-score {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--brand-primary);
+  line-height: 1;
+}
+
+.supplier-card__response-time {
+  font-size: 13px;
+  color: rgba(56, 56, 56, 0.7);
+}
+
+.supplier-card__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: auto;
+}
+
+.supplier-card__actions .btn {
+  width: 100%;
+}
+
+
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: sticky;
+  top: 24px;
+  align-self: start;
+}
+
+.cta-card {
+  background: radial-gradient(circle at top, rgba(60, 177, 195, 0.24), rgba(54, 103, 127, 0.12));
+  border-radius: var(--radius-lg);
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: var(--brand-dark);
+  box-shadow: var(--shadow-sm);
+}
+
+.cta-card h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.cta-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 14px;
+  color: rgba(56, 56, 56, 0.72);
+}
+
+.ad-slot {
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  padding: 18px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ad-slot span {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(56, 56, 56, 0.5);
+}
+
+.ad-slot__content {
+  background: linear-gradient(135deg, rgba(239, 81, 125, 0.1), rgba(141, 207, 219, 0.25));
+  border-radius: var(--radius-sm);
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.ad-slot--tall {
+  min-height: 280px;
+  justify-content: space-between;
+}
+
+.selection-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  width: min(960px, 90vw);
+  background: var(--surface);
+  border-radius: 999px;
+  box-shadow: 0 24px 48px rgba(54, 103, 127, 0.18);
+  padding: 18px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.selection-bar.is-active {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, -8px);
+}
+
+.selection-bar__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.selection-bar__info strong {
+  font-size: 18px;
+}
+
+.selection-bar__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(23, 45, 58, 0.55);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal__dialog {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  width: min(960px, 90vw);
+  max-height: 90vh;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  box-shadow: var(--shadow-md);
+}
+
+.modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal__close {
+  border: none;
+  background: none;
+  font-size: 32px;
+  line-height: 1;
+  color: var(--brand-dark);
+  cursor: pointer;
+}
+
+.modal__content {
+  display: grid;
+  gap: 16px;
+}
+
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.compare-table th,
+.compare-table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid rgba(56, 56, 56, 0.08);
+  text-align: left;
+}
+
+.compare-table th {
+  background: rgba(60, 177, 195, 0.08);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(56, 56, 56, 0.68);
+}
+
+.compare-supplier {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.compare-supplier img {
+  width: 60px;
+  height: 40px;
+  object-fit: contain;
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: rgba(54, 103, 127, 0.08);
+}
+
+@media (max-width: 1200px) {
+  .layout-grid {
+    grid-template-columns: 320px minmax(0, 1fr);
+    gap: 32px;
+  }
+
+  .sidebar {
+    grid-column: span 2;
+    position: static;
+  }
+
+  .sidebar .ad-slot--tall {
+    min-height: auto;
+  }
+}
+
+@media (max-width: 992px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .filters {
+    position: static;
+    order: -1;
+  }
+
+  .results__toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .supplier-card {
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      'selector branding'
+      'selector body'
+      'selector aside';
+    gap: 18px;
+    padding: 20px;
+  }
+
+  .supplier-card__selector {
+    grid-area: selector;
+    align-self: start;
+  }
+
+  .supplier-card__branding {
+    align-items: flex-start;
+    gap: 14px;
+    text-align: left;
+  }
+
+  .supplier-card__logo-wrapper {
+    width: 92px;
+    height: 92px;
+    padding: 12px;
+  }
+
+  .dial {
+    --dial-indicator-offset: 68px;
+  }
+
+  .supplier-card__body {
+    grid-area: body;
+    gap: 16px;
+  }
+
+  .supplier-card__meta {
+    grid-template-columns: 1fr;
+  }
+
+  .site-header__inner {
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .site-header__actions {
+    margin-left: auto;
+  }
+
+  .site-header__search {
+    order: 3;
+    width: 100%;
+  }
+
+  .site-header__nav ul {
+    justify-content: flex-start;
+    overflow-x: auto;
+    gap: 24px;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-shell {
+    padding-bottom: 160px;
+  }
+
+  .masthead__meta {
+    grid-template-columns: 1fr;
+  }
+
+  .insights__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dial {
+    width: 148px;
+    --dial-indicator-offset: 64px;
+  }
+
+  .dial__value {
+    font-size: 32px;
+  }
+
+  .site-header__inner {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .site-header__actions {
+    width: 100%;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .site-header__actions .btn {
+    flex: 1;
+  }
+
+  .site-header__language {
+    flex: 0 0 auto;
+  }
+
+  .site-header__nav ul {
+    flex-wrap: wrap;
+    row-gap: 10px;
+  }
+
+  .selection-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .selection-bar__actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .selection-bar__actions .btn {
+    width: 100%;
+  }
+}
+.supplier-card__media {
+  margin: 0;
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 22px;
+  overflow: hidden;
+  background: rgba(54, 103, 127, 0.08);
+  border: 1px solid rgba(54, 103, 127, 0.12);
+}
+
+.supplier-card__media figcaption {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  margin: 0;
+  pointer-events: none;
+}
+
+.supplier-card__facility {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.supplier-card__logo-wrapper {
+  width: 110px;
+  height: 110px;
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(141, 207, 219, 0.28), rgba(60, 177, 195, 0.14));
+  box-shadow: 0 16px 32px rgba(54, 103, 127, 0.12);
+  border: 1px solid rgba(54, 103, 127, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+}
+
+.supplier-card__logo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.supplier-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 16px;
+  border-radius: 16px;
+  background: rgba(60, 177, 195, 0.18);
+  border: 1px solid rgba(60, 177, 195, 0.36);
+  color: var(--brand-primary);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  box-shadow: 0 12px 24px rgba(60, 177, 195, 0.24);
+}
+
+.supplier-badge--premium {
+  background: linear-gradient(135deg, rgba(239, 81, 125, 0.94), rgba(239, 81, 125, 0.72));
+  color: #fff;
+  box-shadow: 0 16px 34px rgba(239, 81, 125, 0.36);
+  border-color: transparent;
+}
+
+.supplier-badge--verified {
+  background: rgba(60, 177, 195, 0.24);
+  color: var(--brand-primary);
+  border-color: rgba(60, 177, 195, 0.4);
+  box-shadow: 0 12px 28px rgba(60, 177, 195, 0.32);
+}
+
+.supplier-badge--featured {
+  background: rgba(54, 103, 127, 0.2);
+  color: var(--brand-dark);
+  border-color: rgba(54, 103, 127, 0.32);
+  box-shadow: 0 12px 28px rgba(54, 103, 127, 0.28);
+}
+

--- a/ui/product-page/index.html
+++ b/ui/product-page/index.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Paracetamol API Suppliers | Pharmaoffer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__bar">
+        <div class="site-header__inner">
+          <a class="site-header__brand" href="#" aria-label="Pharmaoffer home">
+            <img
+              src="https://pharmaoffer.com/build/images/logo/logopharmaoffer.64b33b10.svg"
+              alt="Pharmaoffer"
+              width="156"
+              height="36"
+              loading="lazy"
+            />
+          </a>
+          <form class="site-header__search" role="search">
+            <label class="visually-hidden" for="global-search">Search</label>
+            <input
+              id="global-search"
+              type="search"
+              name="search"
+              placeholder="Search APIs, suppliers or CAS no."
+            />
+            <button class="btn btn--ghost" type="submit">Search</button>
+          </form>
+          <div class="site-header__actions">
+            <a class="site-header__link" href="#">Log in</a>
+            <button class="site-header__language" type="button" aria-label="Change language">
+              EN
+            </button>
+            <button class="btn btn--primary" type="button">Create inquiry</button>
+          </div>
+        </div>
+      </div>
+      <nav class="site-header__nav" aria-label="Primary">
+        <ul>
+          <li><a href="#">Find API suppliers</a></li>
+          <li><a href="#">Compare CDMOs</a></li>
+          <li><a href="#">Pricing</a></li>
+          <li><a href="#">About us</a></li>
+        </ul>
+      </nav>
+    </header>
+    <div class="page-shell">
+      <header class="masthead">
+        <div class="breadcrumbs">
+          <a href="#">Home</a>
+          <span aria-hidden="true">/</span>
+          <a href="#">APIs</a>
+          <span aria-hidden="true">/</span>
+          <span>Paracetamol</span>
+        </div>
+        <div class="masthead__primary">
+          <div class="masthead__title-group">
+            <h1>Paracetamol API manufacturers &amp; suppliers</h1>
+            <p>
+              Discover GMP-certified suppliers, compare capabilities, and send
+              multi-supplier inquiries in one go.
+            </p>
+          </div>
+          <div class="masthead__meta">
+            <div class="meta-card">
+              <span class="meta-card__label">Avg. offer price</span>
+              <strong>$470 / kg</strong>
+              <small>Based on last 90 days</small>
+            </div>
+            <div class="meta-card">
+              <span class="meta-card__label">Monthly inquiries</span>
+              <strong>1,885</strong>
+              <small>Up 12% vs last month</small>
+            </div>
+            <div class="meta-card">
+              <span class="meta-card__label">Available suppliers</span>
+              <strong>57</strong>
+              <small>17 verified partners</small>
+            </div>
+            <div class="meta-card">
+              <span class="meta-card__label">Avg. lead time</span>
+              <strong>23 days</strong>
+              <small>Ready-to-ship batches</small>
+            </div>
+          </div>
+        </div>
+        <section class="insights">
+          <div class="insights__header">
+            <h2>Market insights</h2>
+            <button class="btn btn--ghost" type="button">
+              Download report
+            </button>
+          </div>
+          <div class="insights__content">
+            <article class="insight-card">
+              <header>
+                <h3>Global price trend</h3>
+                <span class="chip chip--positive">+4.2%</span>
+              </header>
+              <p>Average FOB price evolution over the past 12 months.</p>
+              <svg
+                viewBox="0 0 320 140"
+                role="img"
+                aria-label="Line chart showing upward trend"
+              >
+                <polyline
+                  fill="none"
+                  stroke="var(--brand-secondary)"
+                  stroke-width="6"
+                  stroke-linecap="round"
+                  points="10,120 60,110 110,115 160,90 210,95 260,70 310,65"
+                ></polyline>
+                <line
+                  x1="10"
+                  y1="120"
+                  x2="310"
+                  y2="120"
+                  stroke="var(--brand-light)"
+                  stroke-dasharray="6 8"
+                ></line>
+              </svg>
+            </article>
+            <article class="insight-card">
+              <header>
+                <h3>Top exporting regions</h3>
+                <span class="chip">FY2024</span>
+              </header>
+              <ul class="progress-list">
+                <li>
+                  <span>India</span>
+                  <div class="progress">
+                    <div class="progress__bar" style="width: 68%"></div>
+                    <span class="progress__value">68%</span>
+                  </div>
+                </li>
+                <li>
+                  <span>China</span>
+                  <div class="progress">
+                    <div class="progress__bar" style="width: 52%"></div>
+                    <span class="progress__value">52%</span>
+                  </div>
+                </li>
+                <li>
+                  <span>Europe</span>
+                  <div class="progress">
+                    <div class="progress__bar" style="width: 28%"></div>
+                    <span class="progress__value">28%</span>
+                  </div>
+                </li>
+              </ul>
+            </article>
+            <article class="insight-card">
+              <header>
+                <h3>Transactional health</h3>
+                <span class="chip chip--neutral">Stable</span>
+              </header>
+              <div class="insight-card__body">
+              <div
+                class="dial"
+                role="img"
+                aria-live="polite"
+                aria-label="Transactional health score 64 out of 100"
+                data-role="transactional-dial"
+                data-value="64"
+              >
+                <div class="dial__indicator" aria-hidden="true"></div>
+                <div class="dial__center">
+                  <span class="dial__value">64</span>
+                  <small>On-time deliveries</small>
+                </div>
+              </div>
+                <ul class="dial__legend">
+                  <li>Lead time predictability</li>
+                  <li>Repeat purchase score</li>
+                  <li>Quality compliance</li>
+                </ul>
+              </div>
+            </article>
+          </div>
+        </section>
+      </header>
+
+      <main class="layout-grid">
+        <aside class="filters" aria-label="Filters">
+          <header>
+            <h2>Filter suppliers</h2>
+            <button class="filters__reset" type="button" id="reset-filters">
+              Reset
+            </button>
+          </header>
+          <form id="filters-form">
+            <fieldset>
+              <legend>Compliance</legend>
+              <label class="control control--checkbox">
+                <input type="checkbox" name="compliance" value="gmp" />
+                <span>GMP certified</span>
+              </label>
+              <label class="control control--checkbox">
+                <input type="checkbox" name="compliance" value="fda" />
+                <span>US FDA approved</span>
+              </label>
+              <label class="control control--checkbox">
+                <input type="checkbox" name="compliance" value="who" />
+                <span>WHO prequalified</span>
+              </label>
+            </fieldset>
+            <fieldset>
+              <legend>MOQ (kg)</legend>
+              <input
+                type="range"
+                id="moq"
+                name="moq"
+                min="0"
+                max="1000"
+                value="500"
+              />
+              <div class="range-value">
+                <span id="moq-value">Up to 500 kg</span>
+              </div>
+            </fieldset>
+            <fieldset>
+              <legend>Regions</legend>
+              <label class="control control--checkbox">
+                <input type="checkbox" name="region" value="asia" />
+                <span>Asia</span>
+              </label>
+              <label class="control control--checkbox">
+                <input type="checkbox" name="region" value="europe" />
+                <span>Europe</span>
+              </label>
+              <label class="control control--checkbox">
+                <input type="checkbox" name="region" value="americas" />
+                <span>Americas</span>
+              </label>
+            </fieldset>
+            <fieldset>
+              <legend>Form</legend>
+              <label class="control control--checkbox">
+                <input type="checkbox" name="form" value="powder" />
+                <span>Powder</span>
+              </label>
+              <label class="control control--checkbox">
+                <input type="checkbox" name="form" value="granules" />
+                <span>Granules</span>
+              </label>
+            </fieldset>
+            <fieldset>
+              <legend>Response time</legend>
+              <label class="control control--radio">
+                <input type="radio" name="response" value="24" />
+                <span>&lt; 24h</span>
+              </label>
+              <label class="control control--radio">
+                <input type="radio" name="response" value="48" />
+                <span>&lt; 48h</span>
+              </label>
+              <label class="control control--radio">
+                <input type="radio" name="response" value="72" />
+                <span>&lt; 72h</span>
+              </label>
+            </fieldset>
+          </form>
+        </aside>
+
+        <section class="results" aria-live="polite">
+          <div class="results__toolbar">
+            <span id="results-count">Showing 0 suppliers</span>
+            <div class="toolbar-actions">
+              <label class="control control--select">
+                <span>Sort by</span>
+                <select id="sort-order">
+                  <option value="relevance">Relevance</option>
+                  <option value="rating">Highest rating</option>
+                  <option value="price">Lowest price</option>
+                  <option value="response">Fastest response</option>
+                </select>
+              </label>
+              <button class="btn btn--ghost" type="button" id="compare-btn">
+                Compare selected
+              </button>
+            </div>
+          </div>
+          <div class="supplier-list" id="supplier-list" role="list"></div>
+        </section>
+
+        <aside class="sidebar">
+          <div class="cta-card">
+            <h2>Send multiple inquiries</h2>
+            <p>
+              Select the suppliers you want to contact and send one consolidated
+              brief with just a few clicks.
+            </p>
+            <ul>
+              <li>Attach documents &amp; NDAs</li>
+              <li>Track responses in your inbox</li>
+              <li>Invite colleagues to collaborate</li>
+            </ul>
+            <button class="btn btn--primary" type="button" id="bulk-cta">
+              Start inquiry
+            </button>
+          </div>
+          <div class="ad-slot">
+            <span>Sponsored</span>
+            <div class="ad-slot__content">
+              <p>Promote your manufacturing capacity</p>
+              <button class="btn btn--ghost" type="button">Book ad space</button>
+            </div>
+          </div>
+          <div class="ad-slot ad-slot--tall">
+            <span>Sponsored</span>
+            <div class="ad-slot__content">
+              <p>Showcase your QA capabilities to buyers</p>
+              <button class="btn btn--ghost" type="button">Learn more</button>
+            </div>
+          </div>
+        </aside>
+      </main>
+    </div>
+
+    <div class="selection-bar" id="selection-bar">
+      <div class="selection-bar__info">
+        <strong id="selected-count">0 suppliers selected</strong>
+        <span>Select multiple suppliers to send bulk inquiries.</span>
+      </div>
+      <div class="selection-bar__actions">
+        <button class="btn btn--ghost" type="button" id="clear-selection">
+          Clear selection
+        </button>
+        <button class="btn btn--ghost" type="button" id="selection-compare">
+          Compare
+        </button>
+        <button class="btn btn--primary" type="button" id="inquiry-action">
+          Send inquiries
+        </button>
+      </div>
+    </div>
+
+    <template id="supplier-card-template">
+      <article class="supplier-card" role="listitem">
+        <label class="supplier-card__selector">
+          <input type="checkbox" class="supplier-checkbox" />
+          <span class="checkbox-custom" aria-hidden="true"></span>
+        </label>
+        <div class="supplier-card__branding">
+          <figure class="supplier-card__media">
+            <img
+              class="supplier-card__facility"
+              src=""
+              alt=""
+              loading="lazy"
+            />
+            <figcaption>
+              <span class="supplier-badge" hidden></span>
+            </figcaption>
+          </figure>
+          <div class="supplier-card__logo-wrapper">
+            <img
+              class="supplier-card__logo"
+              src=""
+              alt=""
+              loading="lazy"
+            />
+          </div>
+        </div>
+        <div class="supplier-card__body">
+          <div class="supplier-card__header">
+            <div class="supplier-card__identity">
+              <h3></h3>
+              <p class="supplier-card__subtitle"></p>
+            </div>
+            <span class="supplier-card__rating"></span>
+          </div>
+          <ul class="supplier-card__meta"></ul>
+          <div class="supplier-card__tags"></div>
+        </div>
+        <div class="supplier-card__aside">
+          <div class="supplier-card__response">
+            <span class="supplier-card__response-label">Response rate</span>
+            <strong class="supplier-card__response-score"></strong>
+            <span class="supplier-card__response-time"></span>
+          </div>
+          <div class="supplier-card__actions">
+            <button class="btn btn--ghost btn--small" type="button">
+              View profile
+            </button>
+            <button class="btn btn--primary btn--small" type="button">
+              Quick inquiry
+            </button>
+          </div>
+        </div>
+      </article>
+    </template>
+
+    <div class="modal" id="compare-modal" hidden>
+      <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="compare-title">
+        <header class="modal__header">
+          <h2 id="compare-title">Compare suppliers</h2>
+          <button class="modal__close" type="button" aria-label="Close">
+            &times;
+          </button>
+        </header>
+        <div class="modal__content" id="compare-content"></div>
+      </div>
+    </div>
+
+    <script src="assets/app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- swap the header branding for the official Pharmaoffer logo, add login and language controls, and surface a secondary navigation row
- restyle the header layout for large and small screens so the new menu and actions stay readable across breakpoints
- rebuild supplier branding columns with compact facility imagery, richer badge accents, and data updates to load the provided photos

## Testing
- not run (UI updates only)

------
https://chatgpt.com/codex/tasks/task_e_68db80ba9d888324b61f6eabeb46cb5f