### PR TITLE
Rebuild product hero layout and badge styling

### DIFF
--- a/ui/product-page/assets/app.js
+++ b/ui/product-page/assets/app.js
@@ -227,7 +227,6 @@ const renderSupplierCard = (supplier) => {
   const card = template.content.firstElementChild.cloneNode(true);
   const checkbox = card.querySelector('.supplier-checkbox');
   const logoImage = card.querySelector('.supplier-card__logo');
-  const facilityImage = card.querySelector('.supplier-card__facility');
   const badge = card.querySelector('.supplier-badge');
   const title = card.querySelector('h3');
   const subtitle = card.querySelector('.supplier-card__subtitle');
@@ -242,11 +241,6 @@ const renderSupplierCard = (supplier) => {
 
   logoImage.src = supplier.logo;
   logoImage.alt = `${supplier.name} logo`;
-
-  if (facilityImage) {
-    facilityImage.src = supplier.facility;
-    facilityImage.alt = `${supplier.name} manufacturing facility`;
-  }
 
   if (supplier.badge) {
     badge.textContent = supplier.badge;

--- a/ui/product-page/assets/styles.css
+++ b/ui/product-page/assets/styles.css
@@ -50,7 +50,7 @@ a:hover {
 .page-shell {
   max-width: 1920px;
   margin: 0 auto;
-  padding: 48px clamp(32px, 6vw, 96px) 140px;
+  padding: 32px clamp(32px, 6vw, 96px) 96px;
 }
 
 .site-header {
@@ -69,9 +69,10 @@ a:hover {
   max-width: 1920px;
   margin: 0 auto;
   padding: 14px clamp(28px, 6vw, 96px);
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: clamp(16px, 3vw, 32px);
+  column-gap: clamp(20px, 4vw, 56px);
 }
 
 .site-header__brand {
@@ -87,22 +88,30 @@ a:hover {
 }
 
 .site-header__search {
-  flex: 1;
   display: flex;
   align-items: center;
-  gap: 12px;
-  background: rgba(141, 207, 219, 0.16);
+  gap: 10px;
+  justify-self: center;
+  width: min(100%, 420px);
+  background: rgba(141, 207, 219, 0.14);
   border-radius: 16px;
-  padding: 6px 8px 6px 16px;
+  padding: 4px 6px 4px 16px;
+  box-shadow: inset 0 0 0 1px rgba(54, 103, 127, 0.12);
 }
 
 .site-header__search input {
   flex: 1;
   border: none;
   background: transparent;
-  font-size: 15px;
+  font-size: 14px;
   font-family: inherit;
   color: var(--brand-dark);
+  padding: 8px 0;
+}
+
+.site-header__search .btn {
+  padding: 8px 16px;
+  font-size: 14px;
 }
 
 .site-header__search input:focus {
@@ -153,7 +162,8 @@ a:hover {
 .site-header__nav {
   display: flex;
   justify-content: center;
-  background: rgba(141, 207, 219, 0.12);
+  background: #383838;
+  color: #fff;
 }
 
 .site-header__nav ul {
@@ -163,27 +173,28 @@ a:hover {
   padding: 10px clamp(28px, 6vw, 96px);
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: clamp(18px, 4vw, 64px);
   list-style: none;
 }
 
 .site-header__nav a {
   font-weight: 500;
-  color: rgba(56, 56, 56, 0.8);
+  color: inherit;
   text-decoration: none;
   transition: color 0.2s ease;
 }
 
 .site-header__nav a:hover,
 .site-header__nav a:focus {
-  color: var(--brand-primary);
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .masthead {
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  margin-bottom: 48px;
+  gap: 24px;
+  margin-bottom: 40px;
 }
 
 .breadcrumbs {
@@ -194,35 +205,99 @@ a:hover {
   color: rgba(56, 56, 56, 0.72);
 }
 
-.masthead__primary {
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
+.masthead__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  gap: clamp(24px, 4vw, 48px);
+  align-items: start;
 }
 
 .masthead__title-group h1 {
-  font-size: clamp(32px, 3vw, 44px);
-  margin: 0 0 12px;
+  font-size: clamp(28px, 2.6vw, 36px);
+  margin: 0 0 10px;
   letter-spacing: -0.5px;
 }
 
 .masthead__title-group p {
   margin: 0;
-  font-size: 18px;
-  line-height: 1.6;
+  font-size: 16px;
+  line-height: 1.55;
   color: rgba(56, 56, 56, 0.8);
+}
+
+.product-overview {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(20px, 3vw, 32px);
+}
+
+.product-overview__sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(18px, 3vw, 28px);
+}
+
+.product-overview__section {
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  padding: 20px clamp(16px, 3vw, 28px);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.product-overview__section h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.product-specs,
+.product-metrics {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 14px;
+  font-size: 14px;
+  color: rgba(56, 56, 56, 0.76);
+}
+
+.product-specs div,
+.product-metrics div {
+  display: grid;
+  gap: 2px;
+}
+
+.product-specs dt,
+.product-metrics dt {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(56, 56, 56, 0.56);
+}
+
+.product-specs dd,
+.product-metrics dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--brand-dark);
+}
+
+.intelligence-column {
+  display: grid;
+  gap: clamp(20px, 3vw, 32px);
 }
 
 .masthead__meta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 20px;
+  gap: 18px;
 }
 
 .meta-card {
   background: var(--surface);
   border-radius: var(--radius-md);
-  padding: 20px 24px;
+  padding: 18px 20px;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -248,7 +323,7 @@ a:hover {
 .insights {
   background: linear-gradient(135deg, rgba(60, 177, 195, 0.12), rgba(54, 103, 127, 0.18));
   border-radius: var(--radius-lg);
-  padding: 28px clamp(16px, 3vw, 40px);
+  padding: 24px clamp(16px, 3vw, 36px);
   box-shadow: var(--shadow-sm);
 }
 
@@ -651,14 +726,14 @@ a:hover {
 
 .supplier-card__branding {
   grid-area: branding;
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 18px;
-  padding: 4px 0;
+  gap: 16px;
+  padding: 36px 0 12px;
   text-align: center;
   width: 100%;
-  justify-content: flex-start;
 }
 
 .checkbox-custom {
@@ -1022,6 +1097,10 @@ a:hover {
   .sidebar .ad-slot--tall {
     min-height: auto;
   }
+
+  .masthead__layout {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.95fr);
+  }
 }
 
 @media (max-width: 992px) {
@@ -1056,15 +1135,14 @@ a:hover {
   }
 
   .supplier-card__branding {
-    align-items: flex-start;
-    gap: 14px;
-    text-align: left;
+    align-items: center;
+    gap: 12px;
+    text-align: center;
   }
 
   .supplier-card__logo-wrapper {
-    width: 92px;
-    height: 92px;
-    padding: 12px;
+    width: 96px;
+    padding: 14px;
   }
 
   .dial {
@@ -1080,30 +1158,45 @@ a:hover {
     grid-template-columns: 1fr;
   }
 
-  .site-header__inner {
-    flex-wrap: wrap;
-    gap: 16px;
-  }
-
-  .site-header__actions {
-    margin-left: auto;
-  }
-
   .site-header__search {
-    order: 3;
     width: 100%;
   }
 
   .site-header__nav ul {
-    justify-content: flex-start;
+    justify-content: center;
     overflow-x: auto;
     gap: 24px;
+  }
+
+  .site-header__inner {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: stretch;
+    row-gap: 12px;
+  }
+
+  .site-header__brand {
+    justify-self: start;
+  }
+
+  .site-header__actions {
+    justify-self: stretch;
+    justify-content: flex-start;
+    gap: 16px;
+  }
+
+  .masthead__layout {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .product-overview__sections {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 640px) {
   .page-shell {
-    padding-bottom: 160px;
+    padding-bottom: 140px;
   }
 
   .masthead__meta {
@@ -1120,20 +1213,22 @@ a:hover {
     --dial-indicator-offset: 64px;
   }
 
-  .dial__value {
-    font-size: 32px;
-  }
-
-  .site-header__inner {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 12px;
-  }
-
   .site-header__actions {
     width: 100%;
     justify-content: space-between;
     gap: 12px;
+  }
+
+  .intelligence-column {
+    gap: 24px;
+  }
+
+  .product-overview__section {
+    padding: 18px;
+  }
+
+  .dial__value {
+    font-size: 32px;
   }
 
   .site-header__actions .btn {
@@ -1147,6 +1242,7 @@ a:hover {
   .site-header__nav ul {
     flex-wrap: wrap;
     row-gap: 10px;
+    justify-content: center;
   }
 
   .selection-bar {
@@ -1163,56 +1259,37 @@ a:hover {
     width: 100%;
   }
 }
-.supplier-card__media {
-  margin: 0;
-  position: relative;
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  border-radius: 22px;
-  overflow: hidden;
-  background: rgba(54, 103, 127, 0.08);
-  border: 1px solid rgba(54, 103, 127, 0.12);
-}
-
-.supplier-card__media figcaption {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  margin: 0;
-  pointer-events: none;
-}
-
-.supplier-card__facility {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
-}
-
 .supplier-card__logo-wrapper {
-  width: 110px;
-  height: 110px;
+  width: clamp(96px, 9vw, 120px);
+  aspect-ratio: 1;
   border-radius: 28px;
-  background: linear-gradient(135deg, rgba(141, 207, 219, 0.28), rgba(60, 177, 195, 0.14));
-  box-shadow: 0 16px 32px rgba(54, 103, 127, 0.12);
-  border: 1px solid rgba(54, 103, 127, 0.18);
+  background: linear-gradient(145deg, rgba(141, 207, 219, 0.28), rgba(60, 177, 195, 0.12));
+  background-color: #fff;
+  box-shadow: 0 16px 32px rgba(20, 53, 76, 0.14);
+  border: 1px solid rgba(54, 103, 127, 0.16);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 18px;
+  overflow: hidden;
 }
 
 .supplier-card__logo {
-  width: 100%;
-  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  height: auto;
   object-fit: contain;
 }
 
 .supplier-badge {
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  transform: translateX(-50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 6px 16px;
+  padding: 6px 18px;
   border-radius: 16px;
   background: rgba(60, 177, 195, 0.18);
   border: 1px solid rgba(60, 177, 195, 0.36);

--- a/ui/product-page/index.html
+++ b/ui/product-page/index.html
@@ -62,131 +62,178 @@
           <span aria-hidden="true">/</span>
           <span>Paracetamol</span>
         </div>
-        <div class="masthead__primary">
-          <div class="masthead__title-group">
-            <h1>Paracetamol API manufacturers &amp; suppliers</h1>
-            <p>
-              Discover GMP-certified suppliers, compare capabilities, and send
-              multi-supplier inquiries in one go.
-            </p>
-          </div>
-          <div class="masthead__meta">
-            <div class="meta-card">
-              <span class="meta-card__label">Avg. offer price</span>
-              <strong>$470 / kg</strong>
-              <small>Based on last 90 days</small>
+        <div class="masthead__layout">
+          <section class="product-overview" aria-labelledby="product-overview-title">
+            <div class="masthead__title-group">
+              <h1 id="product-overview-title">Paracetamol API manufacturers &amp; suppliers</h1>
+              <p>
+                Discover GMP-certified suppliers, compare capabilities, and send
+                multi-supplier inquiries in one go.
+              </p>
             </div>
-            <div class="meta-card">
-              <span class="meta-card__label">Monthly inquiries</span>
-              <strong>1,885</strong>
-              <small>Up 12% vs last month</small>
+            <div class="product-overview__sections">
+              <section class="product-overview__section" aria-labelledby="technical-details-title">
+                <h2 id="technical-details-title">Technical details</h2>
+                <dl class="product-specs">
+                  <div>
+                    <dt>CAS number</dt>
+                    <dd>103-90-2</dd>
+                  </div>
+                  <div>
+                    <dt>Synonyms</dt>
+                    <dd>Acetaminophen, p-Hydroxyacetanilide</dd>
+                  </div>
+                  <div>
+                    <dt>Therapeutic area</dt>
+                    <dd>Analgesic · Antipyretic</dd>
+                  </div>
+                  <div>
+                    <dt>Grade availability</dt>
+                    <dd>Pharma · GMP · CEP</dd>
+                  </div>
+                </dl>
+              </section>
+              <section class="product-overview__section" aria-labelledby="market-metrics-title">
+                <h2 id="market-metrics-title">Marketplace metrics</h2>
+                <dl class="product-metrics">
+                  <div>
+                    <dt>Active suppliers</dt>
+                    <dd>57</dd>
+                  </div>
+                  <div>
+                    <dt>Verified partners</dt>
+                    <dd>17</dd>
+                  </div>
+                  <div>
+                    <dt>Yearly transactions</dt>
+                    <dd>4.8K</dd>
+                  </div>
+                  <div>
+                    <dt>Buyer network</dt>
+                    <dd>2.1K</dd>
+                  </div>
+                  <div>
+                    <dt>Quality certificates</dt>
+                    <dd>GMP · WHO · US FDA</dd>
+                  </div>
+                </dl>
+              </section>
             </div>
-            <div class="meta-card">
-              <span class="meta-card__label">Available suppliers</span>
-              <strong>57</strong>
-              <small>17 verified partners</small>
+          </section>
+          <section class="intelligence-column">
+            <div class="masthead__meta">
+              <div class="meta-card">
+                <span class="meta-card__label">Avg. offer price</span>
+                <strong>$470 / kg</strong>
+                <small>Based on last 90 days</small>
+              </div>
+              <div class="meta-card">
+                <span class="meta-card__label">Monthly inquiries</span>
+                <strong>1,885</strong>
+                <small>Up 12% vs last month</small>
+              </div>
+              <div class="meta-card">
+                <span class="meta-card__label">Avg. lead time</span>
+                <strong>23 days</strong>
+                <small>Ready-to-ship batches</small>
+              </div>
             </div>
-            <div class="meta-card">
-              <span class="meta-card__label">Avg. lead time</span>
-              <strong>23 days</strong>
-              <small>Ready-to-ship batches</small>
-            </div>
-          </div>
+            <section class="insights">
+              <div class="insights__header">
+                <h2>Market insights</h2>
+                <button class="btn btn--ghost" type="button">
+                  Download report
+                </button>
+              </div>
+              <div class="insights__content">
+                <article class="insight-card">
+                  <header>
+                    <h3>Global price trend</h3>
+                    <span class="chip chip--positive">+4.2%</span>
+                  </header>
+                  <p>Average FOB price evolution over the past 12 months.</p>
+                  <svg
+                    viewBox="0 0 320 140"
+                    role="img"
+                    aria-label="Line chart showing upward trend"
+                  >
+                    <polyline
+                      fill="none"
+                      stroke="var(--brand-secondary)"
+                      stroke-width="6"
+                      stroke-linecap="round"
+                      points="10,120 60,110 110,115 160,90 210,95 260,70 310,65"
+                    ></polyline>
+                    <line
+                      x1="10"
+                      y1="120"
+                      x2="310"
+                      y2="120"
+                      stroke="var(--brand-light)"
+                      stroke-dasharray="6 8"
+                    ></line>
+                  </svg>
+                </article>
+                <article class="insight-card">
+                  <header>
+                    <h3>Top exporting regions</h3>
+                    <span class="chip">FY2024</span>
+                  </header>
+                  <ul class="progress-list">
+                    <li>
+                      <span>India</span>
+                      <div class="progress">
+                        <div class="progress__bar" style="width: 68%"></div>
+                        <span class="progress__value">68%</span>
+                      </div>
+                    </li>
+                    <li>
+                      <span>China</span>
+                      <div class="progress">
+                        <div class="progress__bar" style="width: 52%"></div>
+                        <span class="progress__value">52%</span>
+                      </div>
+                    </li>
+                    <li>
+                      <span>Europe</span>
+                      <div class="progress">
+                        <div class="progress__bar" style="width: 28%"></div>
+                        <span class="progress__value">28%</span>
+                      </div>
+                    </li>
+                  </ul>
+                </article>
+                <article class="insight-card">
+                  <header>
+                    <h3>Transactional health</h3>
+                    <span class="chip chip--neutral">Stable</span>
+                  </header>
+                  <div class="insight-card__body">
+                    <div
+                      class="dial"
+                      role="img"
+                      aria-live="polite"
+                      aria-label="Transactional health score 64 out of 100"
+                      data-role="transactional-dial"
+                      data-value="64"
+                    >
+                      <div class="dial__indicator" aria-hidden="true"></div>
+                      <div class="dial__center">
+                        <span class="dial__value">64</span>
+                        <small>On-time deliveries</small>
+                      </div>
+                    </div>
+                    <ul class="dial__legend">
+                      <li>Lead time predictability</li>
+                      <li>Repeat purchase score</li>
+                      <li>Quality compliance</li>
+                    </ul>
+                  </div>
+                </article>
+              </div>
+            </section>
+          </section>
         </div>
-        <section class="insights">
-          <div class="insights__header">
-            <h2>Market insights</h2>
-            <button class="btn btn--ghost" type="button">
-              Download report
-            </button>
-          </div>
-          <div class="insights__content">
-            <article class="insight-card">
-              <header>
-                <h3>Global price trend</h3>
-                <span class="chip chip--positive">+4.2%</span>
-              </header>
-              <p>Average FOB price evolution over the past 12 months.</p>
-              <svg
-                viewBox="0 0 320 140"
-                role="img"
-                aria-label="Line chart showing upward trend"
-              >
-                <polyline
-                  fill="none"
-                  stroke="var(--brand-secondary)"
-                  stroke-width="6"
-                  stroke-linecap="round"
-                  points="10,120 60,110 110,115 160,90 210,95 260,70 310,65"
-                ></polyline>
-                <line
-                  x1="10"
-                  y1="120"
-                  x2="310"
-                  y2="120"
-                  stroke="var(--brand-light)"
-                  stroke-dasharray="6 8"
-                ></line>
-              </svg>
-            </article>
-            <article class="insight-card">
-              <header>
-                <h3>Top exporting regions</h3>
-                <span class="chip">FY2024</span>
-              </header>
-              <ul class="progress-list">
-                <li>
-                  <span>India</span>
-                  <div class="progress">
-                    <div class="progress__bar" style="width: 68%"></div>
-                    <span class="progress__value">68%</span>
-                  </div>
-                </li>
-                <li>
-                  <span>China</span>
-                  <div class="progress">
-                    <div class="progress__bar" style="width: 52%"></div>
-                    <span class="progress__value">52%</span>
-                  </div>
-                </li>
-                <li>
-                  <span>Europe</span>
-                  <div class="progress">
-                    <div class="progress__bar" style="width: 28%"></div>
-                    <span class="progress__value">28%</span>
-                  </div>
-                </li>
-              </ul>
-            </article>
-            <article class="insight-card">
-              <header>
-                <h3>Transactional health</h3>
-                <span class="chip chip--neutral">Stable</span>
-              </header>
-              <div class="insight-card__body">
-              <div
-                class="dial"
-                role="img"
-                aria-live="polite"
-                aria-label="Transactional health score 64 out of 100"
-                data-role="transactional-dial"
-                data-value="64"
-              >
-                <div class="dial__indicator" aria-hidden="true"></div>
-                <div class="dial__center">
-                  <span class="dial__value">64</span>
-                  <small>On-time deliveries</small>
-                </div>
-              </div>
-                <ul class="dial__legend">
-                  <li>Lead time predictability</li>
-                  <li>Repeat purchase score</li>
-                  <li>Quality compliance</li>
-                </ul>
-              </div>
-            </article>
-          </div>
-        </section>
       </header>
 
       <main class="layout-grid">
@@ -351,17 +398,7 @@
           <span class="checkbox-custom" aria-hidden="true"></span>
         </label>
         <div class="supplier-card__branding">
-          <figure class="supplier-card__media">
-            <img
-              class="supplier-card__facility"
-              src=""
-              alt=""
-              loading="lazy"
-            />
-            <figcaption>
-              <span class="supplier-badge" hidden></span>
-            </figcaption>
-          </figure>
+          <span class="supplier-badge" hidden></span>
           <div class="supplier-card__logo-wrapper">
             <img
               class="supplier-card__logo"


### PR DESCRIPTION
## Summary
- center and resize the header search bar so it aligns with the primary navigation strip
- rework the hero into a compact two-column layout with technical details, marketplace metrics, and the insights stack grouped in the intelligence column
- float supplier badges above the logo container for the desired overlapping presentation

## Testing
- Not run (static assets only)

------
https://chatgpt.com/codex/tasks/task_e_68dbe681b71083248bcf55c6b7d40fca