### PR TITLE
Make product page layout more compact

### DIFF
--- a/ui/product-page/assets/styles.css
+++ b/ui/product-page/assets/styles.css
@@ -7,12 +7,12 @@
   --surface: #ffffff;
   --surface-alt: #f3fbf9;
   --border: #d6ebe4;
-  --shadow-sm: 0 16px 32px rgba(12, 116, 105, 0.12);
-  --shadow-md: 0 28px 60px rgba(12, 116, 105, 0.16);
-  --radius-xl: 32px;
-  --radius-lg: 24px;
-  --radius-md: 16px;
-  --radius-sm: 12px;
+  --shadow-sm: 0 12px 24px rgba(12, 116, 105, 0.12);
+  --shadow-md: 0 22px 48px rgba(12, 116, 105, 0.16);
+  --radius-xl: 26px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
 }
 
 * {
@@ -51,7 +51,7 @@ a:hover {
 .page-shell {
   max-width: 1920px;
   margin: 0 auto;
-  padding: 32px clamp(32px, 6vw, 96px) 96px;
+  padding: 24px clamp(28px, 5vw, 80px) 72px;
 }
 
 .site-header {
@@ -70,11 +70,11 @@ a:hover {
 .site-header__inner {
   max-width: 1920px;
   margin: 0 auto;
-  padding: 14px clamp(28px, 6vw, 96px);
+  padding: 10px clamp(24px, 5vw, 80px);
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  column-gap: clamp(20px, 4vw, 56px);
+  column-gap: clamp(16px, 3.5vw, 44px);
 }
 
 .site-header__brand {
@@ -92,12 +92,12 @@ a:hover {
 .site-header__search {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   justify-self: center;
-  width: min(100%, 420px);
+  width: min(100%, 380px);
   background: rgba(15, 212, 180, 0.08);
-  border-radius: 18px;
-  padding: 4px 6px 4px 18px;
+  border-radius: 14px;
+  padding: 4px 6px 4px 14px;
   box-shadow: inset 0 0 0 1px rgba(12, 116, 105, 0.18);
 }
 
@@ -105,15 +105,15 @@ a:hover {
   flex: 1;
   border: none;
   background: transparent;
-  font-size: 14px;
+  font-size: 13px;
   font-family: inherit;
   color: var(--brand-dark);
-  padding: 8px 0;
+  padding: 6px 0;
 }
 
 .site-header__search .btn {
-  padding: 8px 16px;
-  font-size: 14px;
+  padding: 6px 14px;
+  font-size: 13px;
 }
 
 .site-header__search input:focus {
@@ -123,7 +123,7 @@ a:hover {
 .site-header__actions {
   display: flex;
   align-items: center;
-  gap: clamp(12px, 3vw, 24px);
+  gap: clamp(10px, 2.6vw, 20px);
 }
 
 .site-header__actions .btn {
@@ -147,8 +147,8 @@ a:hover {
   border: 1px solid rgba(12, 116, 105, 0.16);
   background: rgba(15, 212, 180, 0.16);
   color: var(--brand-primary);
-  border-radius: 14px;
-  padding: 10px 16px;
+  border-radius: 12px;
+  padding: 8px 14px;
   font-weight: 600;
   flex-shrink: 0;
   cursor: pointer;
@@ -170,10 +170,10 @@ a:hover {
 .site-header__nav ul {
   margin: 0 auto;
   max-width: 1600px;
-  padding: 18px clamp(32px, 6vw, 96px) 20px;
+  padding: 14px clamp(28px, 5vw, 80px) 16px;
   display: flex;
   align-items: center;
-  gap: clamp(20px, 4vw, 56px);
+  gap: clamp(18px, 3.4vw, 46px);
   list-style: none;
 }
 
@@ -213,11 +213,11 @@ a:hover {
 .masthead {
   display: flex;
   flex-direction: column;
-  gap: clamp(24px, 4vw, 40px);
-  margin-bottom: clamp(48px, 6vw, 80px);
+  gap: clamp(20px, 3.6vw, 32px);
+  margin-bottom: clamp(38px, 5vw, 64px);
   background: var(--surface);
   border-radius: var(--radius-xl);
-  padding: clamp(36px, 6vw, 56px);
+  padding: clamp(28px, 5vw, 44px);
   box-shadow: var(--shadow-md);
   position: relative;
   overflow: hidden;
@@ -226,10 +226,10 @@ a:hover {
 .breadcrumbs {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  font-size: 14px;
+  gap: 6px;
+  font-size: 13px;
   color: rgba(27, 39, 50, 0.6);
-  padding: 6px 14px;
+  padding: 4px 12px;
   border-radius: 999px;
   background: rgba(12, 116, 105, 0.08);
   width: fit-content;
@@ -238,7 +238,7 @@ a:hover {
 .masthead__layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
-  gap: clamp(14px, 2,5vw, 36px);
+  gap: clamp(12px, 2.2vw, 28px);
   align-items: stretch;
 }
 
@@ -251,10 +251,10 @@ a:hover {
 
 .masthead__title-group p {
   margin: 0;
-  font-size: 18px;
-  line-height: 1.65;
+  font-size: 17px;
+  line-height: 1.55;
   color: rgba(27, 39, 50, 0.7);
-  max-width: 520px;
+  max-width: 500px;
 }
 
 .product-overview {
@@ -265,7 +265,7 @@ a:hover {
     'title title'
     'technical metrics'
     'inquiry inquiry';
-  gap: clamp(24px, 4vw, 40px);
+  gap: clamp(18px, 3.4vw, 30px);
 }
 
 .masthead__title-group {
@@ -279,23 +279,23 @@ a:hover {
 .product-overview__section {
   background: var(--surface);
   border-radius: var(--radius-lg);
-  padding: clamp(22px, 3vw, 32px);
+  padding: clamp(18px, 2.4vw, 26px);
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 14px;
   border: 1px solid rgba(12, 116, 105, 0.08);
 }
 
 .product-overview__section--technical {
   grid-area: technical;
-  gap: 20px;
+  gap: 16px;
 }
 
 .technical-overview {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: clamp(16px, 3vw, 32px);
+  gap: clamp(12px, 2.6vw, 24px);
   align-items: center;
 }
 
@@ -307,14 +307,14 @@ a:hover {
 
 .molecule-diagram {
   margin: 0;
-  padding: 16px;
+  padding: 12px;
   border-radius: var(--radius-md);
   background: rgba(15, 212, 180, 0.12);
   box-shadow: inset 0 0 0 1px rgba(12, 116, 105, 0.15);
   display: grid;
   place-items: center;
-  gap: 12px;
-  max-width: 220px;
+  gap: 10px;
+  max-width: 200px;
 }
 
 .molecule-diagram svg {
@@ -339,8 +339,8 @@ a:hover {
   background: linear-gradient(140deg, rgba(15, 212, 180, 0.12), rgba(12, 116, 105, 0.08));
   color: var(--brand-dark);
   border: 1px solid rgba(12, 116, 105, 0.16);
-  box-shadow: 0 26px 46px rgba(12, 116, 105, 0.16);
-  gap: 20px;
+  box-shadow: 0 22px 38px rgba(12, 116, 105, 0.16);
+  gap: 16px;
 }
 
 .product-overview__section--inquiry h2 {
@@ -350,8 +350,8 @@ a:hover {
 .product-overview__section--inquiry p {
   margin: 0;
   color: rgba(27, 39, 50, 0.75);
-  font-size: 16px;
-  line-height: 1.6;
+  font-size: 15px;
+  line-height: 1.5;
 }
 
 .checklist {
@@ -359,7 +359,7 @@ a:hover {
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 12px;
+  gap: 10px;
   position: relative;
   z-index: 1;
 }
@@ -367,12 +367,12 @@ a:hover {
 .checklist li {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   font-weight: 500;
   color: rgba(27, 39, 50, 0.85);
-  font-size: 15px;
+  font-size: 14px;
   position: relative;
-  padding-left: 32px;
+  padding-left: 28px;
 }
 
 .checklist li::before {
@@ -419,8 +419,8 @@ a:hover {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 14px;
-  font-size: 14px;
+  gap: 12px;
+  font-size: 13px;
   color: rgba(56, 56, 56, 0.76);
 }
 
@@ -430,14 +430,14 @@ a:hover {
   gap: 4px;
   background: var(--surface);
   border-radius: var(--radius-sm);
-  padding: 12px 14px;
+  padding: 10px 12px;
   border: 1px solid rgba(12, 116, 105, 0.08);
-  box-shadow: 0 8px 18px rgba(12, 116, 105, 0.06);
+  box-shadow: 0 8px 18px rgba(12, 116, 105, 0.05);
 }
 
 .product-specs dt,
 .product-metrics dt {
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: rgba(56, 56, 56, 0.56);
@@ -454,20 +454,20 @@ a:hover {
   grid-column: 3;
   align-self: stretch;
   display: grid;
-  gap: clamp(24px, 4vw, 36px);
+  gap: clamp(18px, 3.4vw, 28px);
   grid-template-rows: auto 1fr;
 }
 
 .masthead__meta {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 18px;
+  gap: 14px;
 }
 
 .meta-card {
   background: linear-gradient(145deg, rgba(15, 212, 180, 0.08), rgba(255, 255, 255, 0.9));
   border-radius: var(--radius-lg);
-  padding: 20px 24px;
+  padding: 16px 20px;
   display: flex;
   flex-direction: column;
   gap: 6px;
@@ -476,7 +476,7 @@ a:hover {
 }
 
 .meta-card strong {
-  font-size: 24px;
+  font-size: 22px;
   color: var(--brand-primary);
 }
 
@@ -494,25 +494,25 @@ a:hover {
 .insights {
   background: linear-gradient(135deg, rgba(15, 212, 180, 0.12), rgba(12, 116, 105, 0.18));
   border-radius: var(--radius-xl);
-  padding: 28px clamp(20px, 4vw, 40px);
+  padding: 22px clamp(18px, 3.2vw, 32px);
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 18px;
 }
 
 .insights__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
+  gap: 12px;
 }
 
 .insights__content {
   flex: 1;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
 }
 
 .insights__header h2 {
@@ -694,7 +694,7 @@ a:hover {
 }
 
 .dial__value {
-  font-size: 36px;
+  font-size: 32px;
   font-weight: 700;
   color: var(--brand-primary);
 }
@@ -718,11 +718,11 @@ a:hover {
 .btn {
   border: none;
   border-radius: 999px;
-  padding: 10px 20px;
+  padding: 8px 18px;
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  font-size: 15px;
+  font-size: 14px;
 }
 
 .btn:disabled {
@@ -755,8 +755,8 @@ a:hover {
 }
 
 .btn--small {
-  padding: 8px 16px;
-  font-size: 14px;
+  padding: 6px 14px;
+  font-size: 13px;
 }
 
 .btn:hover {
@@ -766,22 +766,22 @@ a:hover {
 
 .layout-grid {
   display: grid;
-  grid-template-columns: minmax(280px, 320px) minmax(0, 1fr) minmax(300px, 360px);
-  gap: 32px;
+  grid-template-columns: minmax(260px, 300px) minmax(0, 1fr) minmax(280px, 340px);
+  gap: 26px;
   align-items: start;
 }
 
 .filters {
   position: sticky;
-  top: 32px;
+  top: 24px;
   align-self: start;
   background: var(--surface);
   border-radius: var(--radius-lg);
-  padding: 24px;
+  padding: 20px;
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 .filters header {
@@ -792,7 +792,7 @@ a:hover {
 
 .filters h2 {
   margin: 0;
-  font-size: 18px;
+  font-size: 17px;
 }
 
 .filters fieldset {
@@ -822,8 +822,8 @@ a:hover {
 .control {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  font-size: 14px;
+  gap: 8px;
+  font-size: 13px;
   color: rgba(56, 56, 56, 0.84);
 }
 
@@ -864,7 +864,7 @@ a:hover {
 .results {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 .results__toolbar {
@@ -872,7 +872,7 @@ a:hover {
   align-items: center;
   justify-content: space-between;
   background: var(--surface);
-  padding: 20px 24px;
+  padding: 16px 20px;
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
 }
@@ -880,25 +880,25 @@ a:hover {
 .toolbar-actions {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
 .supplier-list {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 
 .supplier-card {
   display: grid;
-  grid-template-columns: auto minmax(220px, 260px) minmax(0, 1fr) minmax(220px, 260px);
+  grid-template-columns: auto minmax(200px, 240px) minmax(0, 1fr) minmax(200px, 240px);
   grid-template-areas: 'selector branding body aside';
-  gap: 24px;
-  padding: 26px;
+  gap: 20px;
+  padding: 22px;
   background: var(--surface);
   border-radius: var(--radius-xl);
-  box-shadow: 0 32px 60px rgba(12, 116, 105, 0.14);
+  box-shadow: 0 26px 48px rgba(12, 116, 105, 0.14);
   align-items: center;
   position: relative;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -917,8 +917,8 @@ a:hover {
 }
 
 .supplier-card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 36px 72px rgba(12, 116, 105, 0.2);
+  transform: translateY(-4px);
+  box-shadow: 0 32px 60px rgba(12, 116, 105, 0.18);
 }
 
 .supplier-card:hover::before {
@@ -1079,10 +1079,10 @@ a:hover {
   gap: 6px;
   background: #fff;
   border-radius: var(--radius-lg);
-  padding: 20px;
+  padding: 16px;
   text-align: center;
   border: 1px solid rgba(12, 116, 105, 0.12);
-  box-shadow: 0 18px 36px rgba(12, 116, 105, 0.12);
+  box-shadow: 0 14px 28px rgba(12, 116, 105, 0.12);
 }
 
 .supplier-card__response-label {
@@ -1094,7 +1094,7 @@ a:hover {
 }
 
 .supplier-card__response-score {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
   color: var(--brand-primary);
   line-height: 1;
@@ -1109,7 +1109,7 @@ a:hover {
 .supplier-card__actions {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
   margin-top: auto;
 }
 
@@ -1122,26 +1122,26 @@ a:hover {
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   position: sticky;
-  top: 24px;
+  top: 20px;
   align-self: start;
 }
 
 .cta-card {
   background: radial-gradient(circle at top, rgba(60, 177, 195, 0.24), rgba(54, 103, 127, 0.12));
   border-radius: var(--radius-lg);
-  padding: 28px 24px;
+  padding: 22px 20px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   color: var(--brand-dark);
   box-shadow: var(--shadow-sm);
 }
 
 .cta-card h2 {
   margin: 0;
-  font-size: 22px;
+  font-size: 20px;
 }
 
 .cta-card ul {
@@ -1150,19 +1150,19 @@ a:hover {
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  font-size: 14px;
+  gap: 8px;
+  font-size: 13px;
   color: rgba(56, 56, 56, 0.72);
 }
 
 .ad-slot {
   background: var(--surface);
   border-radius: var(--radius-md);
-  padding: 18px;
+  padding: 16px;
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .ad-slot span {
@@ -1175,30 +1175,30 @@ a:hover {
 .ad-slot__content {
   background: linear-gradient(135deg, rgba(239, 81, 125, 0.1), rgba(141, 207, 219, 0.25));
   border-radius: var(--radius-sm);
-  padding: 18px;
+  padding: 16px;
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
 .ad-slot--tall {
-  min-height: 280px;
+  min-height: 240px;
   justify-content: space-between;
 }
 
 .selection-bar {
   position: fixed;
   left: 50%;
-  bottom: 24px;
+  bottom: 18px;
   transform: translateX(-50%);
-  width: min(960px, 90vw);
+  width: min(920px, 90vw);
   background: var(--surface);
   border-radius: 999px;
-  box-shadow: 0 24px 48px rgba(54, 103, 127, 0.18);
-  padding: 18px 28px;
+  box-shadow: 0 20px 40px rgba(54, 103, 127, 0.18);
+  padding: 14px 24px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
+  gap: 20px;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease, transform 0.3s ease;
@@ -1207,22 +1207,22 @@ a:hover {
 .selection-bar.is-active {
   opacity: 1;
   pointer-events: auto;
-  transform: translate(-50%, -8px);
+  transform: translate(-50%, -6px);
 }
 
 .selection-bar__info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .selection-bar__info strong {
-  font-size: 18px;
+  font-size: 17px;
 }
 
 .selection-bar__actions {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
@@ -1232,7 +1232,7 @@ a:hover {
   background: rgba(23, 45, 58, 0.55);
   display: grid;
   place-items: center;
-  padding: 24px;
+  padding: 20px;
 }
 
 .modal[hidden] {
@@ -1242,13 +1242,13 @@ a:hover {
 .modal__dialog {
   background: var(--surface);
   border-radius: var(--radius-lg);
-  padding: 28px;
+  padding: 24px;
   width: min(960px, 90vw);
   max-height: 90vh;
   overflow: auto;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
   box-shadow: var(--shadow-md);
 }
 
@@ -1261,7 +1261,7 @@ a:hover {
 .modal__close {
   border: none;
   background: none;
-  font-size: 32px;
+  font-size: 28px;
   line-height: 1;
   color: var(--brand-dark);
   cursor: pointer;
@@ -1269,38 +1269,38 @@ a:hover {
 
 .modal__content {
   display: grid;
-  gap: 16px;
+  gap: 14px;
 }
 
 .rfq-form {
   display: grid;
-  gap: 20px;
+  gap: 16px;
 }
 
 .rfq-form__grid {
   display: grid;
-  gap: 16px;
+  gap: 14px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .rfq-form label span {
   display: block;
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: rgba(56, 56, 56, 0.6);
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 
 .rfq-form input,
 .rfq-form select,
 .rfq-form textarea {
   width: 100%;
-  padding: 12px 14px;
-  border-radius: 14px;
+  padding: 10px 12px;
+  border-radius: 12px;
   border: 1px solid rgba(54, 103, 127, 0.2);
   font-family: inherit;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--brand-dark);
   background: rgba(255, 255, 255, 0.92);
 }
@@ -1315,24 +1315,24 @@ a:hover {
 .rfq-form__quantity {
   display: grid;
   grid-template-columns: 1fr 120px;
-  gap: 10px;
+  gap: 8px;
 }
 
 .rfq-form__textarea textarea {
   resize: vertical;
-  min-height: 120px;
+  min-height: 110px;
 }
 
 .rfq-form__actions {
   display: flex;
   justify-content: space-between;
-  gap: 16px;
+  gap: 14px;
   flex-wrap: wrap;
 }
 
 .rfq-form__actions .btn {
   flex: 1;
-  min-width: 220px;
+  min-width: 200px;
 }
 
 .modal__success {


### PR DESCRIPTION
## Summary
- reduce default radii, shadows, gaps, and paddings to tighten the layout without changing the page width
- shrink header, masthead, supplier cards, sidebar widgets, and RFQ modal elements so more information fits above the fold
- keep typography legible by modestly adjusting font sizes and control dimensions to match the denser layout

## Testing
- Manual UI check

------
https://chatgpt.com/codex/tasks/task_e_68de4d00844083249c1928956d831b28