### PR TITLE
Make product page layout more compact

### DIFF
--- a/ui/product-page/assets/styles.css
+++ b/ui/product-page/assets/styles.css
@@ -25,6 +25,7 @@ body {
     sans-serif;
   color: var(--brand-dark);
   background: linear-gradient(120deg, #ffffff 0%, #f4fbf9 55%, #eef7ff 100%);
+  font-size: 15px;
 }
 
 .visually-hidden {
@@ -51,7 +52,7 @@ a:hover {
 .page-shell {
   max-width: 1920px;
   margin: 0 auto;
-  padding: 24px clamp(28px, 5vw, 80px) 72px;
+  padding: 20px clamp(24px, 4vw, 64px) 48px;
 }
 
 .site-header {
@@ -70,11 +71,11 @@ a:hover {
 .site-header__inner {
   max-width: 1920px;
   margin: 0 auto;
-  padding: 10px clamp(24px, 5vw, 80px);
+  padding: 6px clamp(20px, 4vw, 64px);
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  column-gap: clamp(16px, 3.5vw, 44px);
+  column-gap: clamp(12px, 3vw, 32px);
 }
 
 .site-header__brand {
@@ -92,12 +93,12 @@ a:hover {
 .site-header__search {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   justify-self: center;
-  width: min(100%, 380px);
+  width: min(100%, 340px);
   background: rgba(15, 212, 180, 0.08);
-  border-radius: 14px;
-  padding: 4px 6px 4px 14px;
+  border-radius: 12px;
+  padding: 2px 4px 2px 12px;
   box-shadow: inset 0 0 0 1px rgba(12, 116, 105, 0.18);
 }
 
@@ -105,15 +106,15 @@ a:hover {
   flex: 1;
   border: none;
   background: transparent;
-  font-size: 13px;
+  font-size: 12px;
   font-family: inherit;
   color: var(--brand-dark);
-  padding: 6px 0;
+  padding: 4px 0;
 }
 
 .site-header__search .btn {
-  padding: 6px 14px;
-  font-size: 13px;
+  padding: 6px 12px;
+  font-size: 12px;
 }
 
 .site-header__search input:focus {
@@ -123,7 +124,7 @@ a:hover {
 .site-header__actions {
   display: flex;
   align-items: center;
-  gap: clamp(10px, 2.6vw, 20px);
+  gap: clamp(8px, 2vw, 16px);
 }
 
 .site-header__actions .btn {
@@ -134,6 +135,7 @@ a:hover {
   font-weight: 500;
   color: var(--brand-dark);
   text-decoration: none;
+  font-size: 14px;
   transition: color 0.2s ease;
   flex-shrink: 0;
 }
@@ -148,7 +150,7 @@ a:hover {
   background: rgba(15, 212, 180, 0.16);
   color: var(--brand-primary);
   border-radius: 12px;
-  padding: 8px 14px;
+  padding: 6px 12px;
   font-weight: 600;
   flex-shrink: 0;
   cursor: pointer;
@@ -170,10 +172,10 @@ a:hover {
 .site-header__nav ul {
   margin: 0 auto;
   max-width: 1600px;
-  padding: 14px clamp(28px, 5vw, 80px) 16px;
+  padding: 10px clamp(24px, 4vw, 64px) 12px;
   display: flex;
   align-items: center;
-  gap: clamp(18px, 3.4vw, 46px);
+  gap: clamp(14px, 3vw, 36px);
   list-style: none;
 }
 
@@ -183,6 +185,7 @@ a:hover {
   color: rgba(27, 39, 50, 0.72);
   text-decoration: none;
   padding-bottom: 6px;
+  font-size: 14px;
   transition: color 0.2s ease;
 }
 
@@ -213,11 +216,11 @@ a:hover {
 .masthead {
   display: flex;
   flex-direction: column;
-  gap: clamp(20px, 3.6vw, 32px);
-  margin-bottom: clamp(38px, 5vw, 64px);
+  gap: clamp(16px, 3vw, 28px);
+  margin-bottom: clamp(28px, 4vw, 48px);
   background: var(--surface);
   border-radius: var(--radius-xl);
-  padding: clamp(28px, 5vw, 44px);
+  padding: clamp(22px, 4vw, 36px);
   box-shadow: var(--shadow-md);
   position: relative;
   overflow: hidden;
@@ -238,23 +241,23 @@ a:hover {
 .masthead__layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
-  gap: clamp(12px, 2.2vw, 28px);
+  gap: clamp(10px, 2vw, 24px);
   align-items: stretch;
 }
 
 .masthead__title-group h1 {
-  font-size: clamp(34px, 4.2vw, 52px);
-  margin: 0 0 clamp(10px, 2vw, 18px);
-  letter-spacing: -0.04em;
-  line-height: 1.05;
+  font-size: clamp(28px, 3.4vw, 40px);
+  margin: 0 0 clamp(8px, 1.8vw, 14px);
+  letter-spacing: -0.03em;
+  line-height: 1.1;
 }
 
 .masthead__title-group p {
   margin: 0;
-  font-size: 17px;
-  line-height: 1.55;
+  font-size: 15px;
+  line-height: 1.45;
   color: rgba(27, 39, 50, 0.7);
-  max-width: 500px;
+  max-width: 480px;
 }
 
 .product-overview {
@@ -265,7 +268,7 @@ a:hover {
     'title title'
     'technical metrics'
     'inquiry inquiry';
-  gap: clamp(18px, 3.4vw, 30px);
+  gap: clamp(14px, 3vw, 26px);
 }
 
 .masthead__title-group {
@@ -279,11 +282,11 @@ a:hover {
 .product-overview__section {
   background: var(--surface);
   border-radius: var(--radius-lg);
-  padding: clamp(18px, 2.4vw, 26px);
+  padding: clamp(14px, 2vw, 22px);
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
   border: 1px solid rgba(12, 116, 105, 0.08);
 }
 
@@ -294,9 +297,9 @@ a:hover {
 
 .technical-overview {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: clamp(12px, 2.6vw, 24px);
-  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: clamp(10px, 2vw, 18px);
+  align-items: start;
 }
 
 .technical-overview__header {
@@ -305,30 +308,6 @@ a:hover {
   justify-content: space-between;
 }
 
-.molecule-diagram {
-  margin: 0;
-  padding: 12px;
-  border-radius: var(--radius-md);
-  background: rgba(15, 212, 180, 0.12);
-  box-shadow: inset 0 0 0 1px rgba(12, 116, 105, 0.15);
-  display: grid;
-  place-items: center;
-  gap: 10px;
-  max-width: 200px;
-}
-
-.molecule-diagram svg {
-  width: 100%;
-  height: auto;
-}
-
-.molecule-diagram figcaption {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(56, 56, 56, 0.6);
-  text-align: center;
-}
 
 .product-overview__sections > section:last-of-type {
   grid-area: metrics;
@@ -339,19 +318,19 @@ a:hover {
   background: linear-gradient(140deg, rgba(15, 212, 180, 0.12), rgba(12, 116, 105, 0.08));
   color: var(--brand-dark);
   border: 1px solid rgba(12, 116, 105, 0.16);
-  box-shadow: 0 22px 38px rgba(12, 116, 105, 0.16);
-  gap: 16px;
+  box-shadow: 0 18px 32px rgba(12, 116, 105, 0.14);
+  gap: 14px;
 }
 
 .product-overview__section--inquiry h2 {
-  font-size: clamp(22px, 3vw, 30px);
+  font-size: clamp(20px, 2.6vw, 26px);
 }
 
 .product-overview__section--inquiry p {
   margin: 0;
   color: rgba(27, 39, 50, 0.75);
-  font-size: 15px;
-  line-height: 1.5;
+  font-size: 14px;
+  line-height: 1.4;
 }
 
 .checklist {
@@ -367,35 +346,35 @@ a:hover {
 .checklist li {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   font-weight: 500;
   color: rgba(27, 39, 50, 0.85);
-  font-size: 14px;
+  font-size: 13px;
   position: relative;
-  padding-left: 28px;
+  padding-left: 24px;
 }
 
 .checklist li::before {
   content: '';
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--brand-secondary), var(--brand-primary));
-  box-shadow: 0 8px 18px rgba(12, 116, 105, 0.28);
+  box-shadow: 0 6px 14px rgba(12, 116, 105, 0.24);
   position: absolute;
   left: 0;
 }
 
 .checklist li::after {
   content: '';
-  width: 6px;
-  height: 10px;
+  width: 5px;
+  height: 8px;
   border-right: 2px solid #fff;
   border-bottom: 2px solid #fff;
   transform: rotate(45deg);
   position: absolute;
-  left: 6px;
-  top: 4px;
+  left: 5px;
+  top: 3px;
 }
 
 .btn--block {
@@ -410,7 +389,7 @@ a:hover {
 
 .product-overview__section h2 {
   margin: 0;
-  font-size: 18px;
+  font-size: 16px;
   color: var(--brand-primary);
 }
 
@@ -419,9 +398,10 @@ a:hover {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 12px;
-  font-size: 13px;
+  gap: 10px;
+  font-size: 12px;
   color: rgba(56, 56, 56, 0.76);
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
 }
 
 .product-specs div,
@@ -430,14 +410,14 @@ a:hover {
   gap: 4px;
   background: var(--surface);
   border-radius: var(--radius-sm);
-  padding: 10px 12px;
+  padding: 8px 10px;
   border: 1px solid rgba(12, 116, 105, 0.08);
-  box-shadow: 0 8px 18px rgba(12, 116, 105, 0.05);
+  box-shadow: 0 6px 14px rgba(12, 116, 105, 0.05);
 }
 
 .product-specs dt,
 .product-metrics dt {
-  font-size: 11px;
+  font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: rgba(56, 56, 56, 0.56);
@@ -454,34 +434,34 @@ a:hover {
   grid-column: 3;
   align-self: stretch;
   display: grid;
-  gap: clamp(18px, 3.4vw, 28px);
+  gap: clamp(14px, 3vw, 24px);
   grid-template-rows: auto 1fr;
 }
 
 .masthead__meta {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
 }
 
 .meta-card {
   background: linear-gradient(145deg, rgba(15, 212, 180, 0.08), rgba(255, 255, 255, 0.9));
   border-radius: var(--radius-lg);
-  padding: 16px 20px;
+  padding: 14px 16px;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
   box-shadow: var(--shadow-sm);
   border: 1px solid rgba(12, 116, 105, 0.08);
 }
 
 .meta-card strong {
-  font-size: 22px;
+  font-size: 20px;
   color: var(--brand-primary);
 }
 
 .meta-card__label {
-  font-size: 14px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: rgba(56, 56, 56, 0.64);
@@ -494,30 +474,30 @@ a:hover {
 .insights {
   background: linear-gradient(135deg, rgba(15, 212, 180, 0.12), rgba(12, 116, 105, 0.18));
   border-radius: var(--radius-xl);
-  padding: 22px clamp(18px, 3.2vw, 32px);
+  padding: 18px clamp(16px, 3vw, 28px);
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 14px;
 }
 
 .insights__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .insights__content {
   flex: 1;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
 }
 
 .insights__header h2 {
   margin: 0;
-  font-size: 24px;
+  font-size: 20px;
 }
 
 .insight-card {
@@ -694,14 +674,14 @@ a:hover {
 }
 
 .dial__value {
-  font-size: 32px;
+  font-size: 26px;
   font-weight: 700;
   color: var(--brand-primary);
 }
 
 .dial small {
   color: rgba(56, 56, 56, 0.64);
-  font-size: 14px;
+  font-size: 12px;
 }
 
 .dial__legend {
@@ -710,19 +690,19 @@ a:hover {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  font-size: 14px;
+  gap: 6px;
+  font-size: 12px;
   color: rgba(56, 56, 56, 0.72);
 }
 
 .btn {
   border: none;
   border-radius: 999px;
-  padding: 8px 18px;
+  padding: 6px 16px;
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .btn:disabled {
@@ -755,8 +735,8 @@ a:hover {
 }
 
 .btn--small {
-  padding: 6px 14px;
-  font-size: 13px;
+  padding: 4px 12px;
+  font-size: 12px;
 }
 
 .btn:hover {
@@ -766,8 +746,8 @@ a:hover {
 
 .layout-grid {
   display: grid;
-  grid-template-columns: minmax(260px, 300px) minmax(0, 1fr) minmax(280px, 340px);
-  gap: 26px;
+  grid-template-columns: minmax(240px, 280px) minmax(0, 1fr) minmax(260px, 320px);
+  gap: 22px;
   align-items: start;
 }
 
@@ -777,11 +757,11 @@ a:hover {
   align-self: start;
   background: var(--surface);
   border-radius: var(--radius-lg);
-  padding: 20px;
+  padding: 16px;
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
 }
 
 .filters header {
@@ -792,7 +772,7 @@ a:hover {
 
 .filters h2 {
   margin: 0;
-  font-size: 17px;
+  font-size: 15px;
 }
 
 .filters fieldset {
@@ -807,7 +787,7 @@ a:hover {
 .filters legend {
   font-weight: 600;
   margin-bottom: 4px;
-  font-size: 14px;
+  font-size: 13px;
   color: rgba(56, 56, 56, 0.72);
 }
 
@@ -822,8 +802,8 @@ a:hover {
 .control {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
+  gap: 6px;
+  font-size: 12px;
   color: rgba(56, 56, 56, 0.84);
 }
 
@@ -844,27 +824,27 @@ a:hover {
 .control--select {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 14px;
+  gap: 6px;
+  font-size: 13px;
   color: rgba(56, 56, 56, 0.72);
 }
 
 .control--select select {
-  padding: 8px 12px;
+  padding: 6px 10px;
   border-radius: 999px;
   border: 1px solid rgba(54, 103, 127, 0.24);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .range-value {
-  font-size: 13px;
+  font-size: 12px;
   color: rgba(56, 56, 56, 0.68);
 }
 
 .results {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
 }
 
 .results__toolbar {
@@ -872,7 +852,7 @@ a:hover {
   align-items: center;
   justify-content: space-between;
   background: var(--surface);
-  padding: 16px 20px;
+  padding: 12px 16px;
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
 }
@@ -880,25 +860,25 @@ a:hover {
 .toolbar-actions {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
 }
 
 .supplier-list {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
 }
 
 
 .supplier-card {
   display: grid;
-  grid-template-columns: auto minmax(200px, 240px) minmax(0, 1fr) minmax(200px, 240px);
+  grid-template-columns: auto minmax(180px, 220px) minmax(0, 1fr) minmax(180px, 220px);
   grid-template-areas: 'selector branding body aside';
-  gap: 20px;
-  padding: 22px;
+  gap: 16px;
+  padding: 18px;
   background: var(--surface);
   border-radius: var(--radius-xl);
-  box-shadow: 0 26px 48px rgba(12, 116, 105, 0.14);
+  box-shadow: 0 22px 40px rgba(12, 116, 105, 0.12);
   align-items: center;
   position: relative;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -942,12 +922,12 @@ a:hover {
   grid-area: branding;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   align-items: flex-start;
   justify-content: flex-start;
   width: 100%;
-  height:100%;
-  padding: 22px 24px;
+  height: 100%;
+  padding: 18px 20px;
   border-radius: var(--radius-lg);
   background: linear-gradient(160deg, rgba(15, 212, 180, 0.1), rgba(255, 255, 255, 0.9));
   border: 1px solid rgba(12, 116, 105, 0.12);
@@ -982,7 +962,7 @@ a:hover {
   grid-area: body;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 14px;
 }
 
 
@@ -990,16 +970,16 @@ a:hover {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
 }
 
 .supplier-card__rating {
   font-weight: 600;
   color: var(--brand-primary);
   background: rgba(15, 212, 180, 0.14);
-  padding: 8px 14px;
+  padding: 6px 12px;
   border-radius: 12px;
-  font-size: 13px;
+  font-size: 12px;
   box-shadow: inset 0 0 0 1px rgba(12, 116, 105, 0.12);
 }
 
@@ -1012,20 +992,20 @@ a:hover {
 
 .supplier-card__header h3 {
   margin: 0;
-  font-size: 18px;
+  font-size: 16px;
 }
 
 .supplier-card__subtitle {
   margin: 4px 0 0;
   color: rgba(56, 56, 56, 0.64);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 
 .supplier-card__meta {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 12px;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -1033,12 +1013,12 @@ a:hover {
 
 .supplier-card__meta li {
   display: grid;
-  gap: 6px;
+  gap: 4px;
   background: var(--surface);
   border-radius: var(--radius-sm);
-  padding: 14px 16px;
+  padding: 12px 14px;
   border: 1px solid rgba(12, 116, 105, 0.08);
-  box-shadow: 0 12px 24px rgba(12, 116, 105, 0.08);
+  box-shadow: 0 10px 20px rgba(12, 116, 105, 0.08);
 }
 
 .supplier-card__meta li span {
@@ -1050,15 +1030,15 @@ a:hover {
 .supplier-card__tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
 }
 
 .supplier-card__tags span {
-  padding: 6px 14px;
+  padding: 4px 12px;
   border-radius: 999px;
   background: rgba(15, 212, 180, 0.14);
   color: var(--brand-primary);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -1069,7 +1049,7 @@ a:hover {
   grid-area: aside;
   display: flex;
   flex-direction: column;
-  gap: 18px;
+  gap: 14px;
   align-items: stretch;
   justify-self: stretch;
 }
@@ -1079,14 +1059,14 @@ a:hover {
   gap: 6px;
   background: #fff;
   border-radius: var(--radius-lg);
-  padding: 16px;
+  padding: 12px;
   text-align: center;
   border: 1px solid rgba(12, 116, 105, 0.12);
-  box-shadow: 0 14px 28px rgba(12, 116, 105, 0.12);
+  box-shadow: 0 12px 24px rgba(12, 116, 105, 0.12);
 }
 
 .supplier-card__response-label {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -1094,14 +1074,14 @@ a:hover {
 }
 
 .supplier-card__response-score {
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 700;
   color: var(--brand-primary);
   line-height: 1;
 }
 
 .supplier-card__response-time {
-  font-size: 13px;
+  font-size: 12px;
   color: rgba(56, 56, 56, 0.7);
 }
 
@@ -1109,7 +1089,7 @@ a:hover {
 .supplier-card__actions {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   margin-top: auto;
 }
 
@@ -1122,7 +1102,7 @@ a:hover {
 .sidebar {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 14px;
   position: sticky;
   top: 20px;
   align-self: start;
@@ -1131,17 +1111,17 @@ a:hover {
 .cta-card {
   background: radial-gradient(circle at top, rgba(60, 177, 195, 0.24), rgba(54, 103, 127, 0.12));
   border-radius: var(--radius-lg);
-  padding: 22px 20px;
+  padding: 18px 18px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
   color: var(--brand-dark);
   box-shadow: var(--shadow-sm);
 }
 
 .cta-card h2 {
   margin: 0;
-  font-size: 20px;
+  font-size: 18px;
 }
 
 .cta-card ul {
@@ -1150,19 +1130,19 @@ a:hover {
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  font-size: 13px;
+  gap: 6px;
+  font-size: 12px;
   color: rgba(56, 56, 56, 0.72);
 }
 
 .ad-slot {
   background: var(--surface);
   border-radius: var(--radius-md);
-  padding: 16px;
+  padding: 12px;
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .ad-slot span {
@@ -1175,9 +1155,9 @@ a:hover {
 .ad-slot__content {
   background: linear-gradient(135deg, rgba(239, 81, 125, 0.1), rgba(141, 207, 219, 0.25));
   border-radius: var(--radius-sm);
-  padding: 16px;
+  padding: 12px;
   display: grid;
-  gap: 10px;
+  gap: 8px;
 }
 
 .ad-slot--tall {
@@ -1188,17 +1168,17 @@ a:hover {
 .selection-bar {
   position: fixed;
   left: 50%;
-  bottom: 18px;
+  bottom: 16px;
   transform: translateX(-50%);
   width: min(920px, 90vw);
   background: var(--surface);
   border-radius: 999px;
   box-shadow: 0 20px 40px rgba(54, 103, 127, 0.18);
-  padding: 14px 24px;
+  padding: 12px 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 20px;
+  gap: 16px;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease, transform 0.3s ease;
@@ -1217,12 +1197,12 @@ a:hover {
 }
 
 .selection-bar__info strong {
-  font-size: 17px;
+  font-size: 15px;
 }
 
 .selection-bar__actions {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
 }
 
@@ -1232,7 +1212,7 @@ a:hover {
   background: rgba(23, 45, 58, 0.55);
   display: grid;
   place-items: center;
-  padding: 20px;
+  padding: 16px;
 }
 
 .modal[hidden] {
@@ -1242,13 +1222,13 @@ a:hover {
 .modal__dialog {
   background: var(--surface);
   border-radius: var(--radius-lg);
-  padding: 24px;
+  padding: 20px;
   width: min(960px, 90vw);
   max-height: 90vh;
   overflow: auto;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   box-shadow: var(--shadow-md);
 }
 
@@ -1274,12 +1254,12 @@ a:hover {
 
 .rfq-form {
   display: grid;
-  gap: 16px;
+  gap: 14px;
 }
 
 .rfq-form__grid {
   display: grid;
-  gap: 14px;
+  gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
@@ -1326,7 +1306,7 @@ a:hover {
 .rfq-form__actions {
   display: flex;
   justify-content: space-between;
-  gap: 14px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
@@ -1337,9 +1317,9 @@ a:hover {
 
 .modal__success {
   display: grid;
-  gap: 12px;
+  gap: 10px;
   text-align: center;
-  padding: 24px;
+  padding: 18px;
   border-radius: var(--radius-md);
   background: rgba(60, 177, 195, 0.12);
   box-shadow: inset 0 0 0 1px rgba(54, 103, 127, 0.14);
@@ -1352,12 +1332,12 @@ a:hover {
 .compare-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .compare-table th,
 .compare-table td {
-  padding: 12px 16px;
+  padding: 10px 14px;
   border-bottom: 1px solid rgba(56, 56, 56, 0.08);
   text-align: left;
 }
@@ -1373,7 +1353,7 @@ a:hover {
 .compare-supplier {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
 }
 
 .compare-supplier img {
@@ -1527,10 +1507,6 @@ a:hover {
   .technical-overview {
     grid-template-columns: 1fr;
   }
-
-  .molecule-diagram {
-    justify-self: start;
-  }
 }
 
 @media (max-width: 640px) {
@@ -1567,7 +1543,7 @@ a:hover {
   }
 
   .dial__value {
-    font-size: 32px;
+    font-size: 28px;
   }
 
   .site-header__actions .btn {

--- a/ui/product-page/index.html
+++ b/ui/product-page/index.html
@@ -106,31 +106,6 @@
                       <dd>151.16 g/mol</dd>
                     </div>
                   </dl>
-                  <figure
-                    class="molecule-diagram"
-                    role="img"
-                    aria-labelledby="molecule-caption"
-                  >
-                    <svg viewBox="0 0 220 180" aria-hidden="true">
-                      <g
-                        fill="none"
-                        stroke="rgba(54, 103, 127, 0.6)"
-                        stroke-width="6"
-                        stroke-linecap="round"
-                      >
-                        <path d="M40 90 L80 40 L140 40 L180 90 L140 140 L80 140 Z" />
-                        <path d="M40 90 L20 130" />
-                        <path d="M80 40 L80 10" />
-                        <path d="M140 40 L180 10" />
-                        <path d="M180 90 L210 90" />
-                        <path d="M140 140 L160 170" />
-                        <path d="M80 140 L40 170" />
-                      </g>
-                    </svg>
-                    <figcaption id="molecule-caption">
-                      Paracetamol molecular structure
-                    </figcaption>
-                  </figure>
                 </div>
               </section>
               <section


### PR DESCRIPTION
## Summary
- tighten spacing and typography across the header, hero, metrics, supplier cards, and auxiliary panels to display more content at once
- update technical details to auto-fit columns and remove the decorative molecule illustration for a cleaner overview

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68de4efcbf108324912b1f4dbcf7e814